### PR TITLE
[PLAY-901] Changed settings service to user env variable for AWS region

### DIFF
--- a/app/services/settings_service/repository_base.rb
+++ b/app/services/settings_service/repository_base.rb
@@ -7,7 +7,7 @@ module SettingsService
       @secret_key = ENV['S3_ACCESS_KEY']
       @id_key = ENV['S3_ACCESS_KEY_ID']
       Aws.config.update(
-        region: 'us-west-2',
+        region: ENV['AWS_REGION'],
         credentials: creds
       )
     end


### PR DESCRIPTION
### Tickets for this PR
 [PLAY-901](https://strongmind.atlassian.net/browse/PLAY-901)

### Changes in this PR
- Used env var for AWS Region in settings service instead of hardcoded string