### PR TITLE
Add dynamodb waiter to block until table created

### DIFF
--- a/app/services/settings_service/repository_base.rb
+++ b/app/services/settings_service/repository_base.rb
@@ -24,6 +24,7 @@ module SettingsService
     def create_table(name:)
       begin
         dynamodb.create_table(table_params(name)).successful?
+        dynamodb.wait_until(:table_exists, {table_name: name})
       rescue
       end
     end


### PR DESCRIPTION
### Changes in this PR
- DyamoDB table creation is asynchronous. The return on the table creation is a status of CREATING. In the current implementation of the SettingsService, when a table creation is requested, we aren't waiting for the completion of that request. This returns `nil` from a rescue block when settings are fetched for the first time. Attempting to access the settings key off a `nil` return, we get method error. 

I've added the use of the AWS `:table_exists` waiter to block until the table has actually been created. This will check for table creation every 20 seconds for table creation, up to 500 seconds. 