### PR TITLE
Add return URL back to Canvas on reset email

### DIFF
--- a/app/decorators/models/user_decorator.rb
+++ b/app/decorators/models/user_decorator.rb
@@ -226,7 +226,8 @@ User.class_eval do
         "FirstName" => first_name,
         "LastName" => last_name,
         "Email" => identity_email,
-        "SendPasswordResetEmail": true
+        "SendPasswordResetEmail": true,
+        "PasswordResetReturnUrl": "http://#{ENV['CANVAS_DOMAIN']}"
       }.to_json,
       :headers => {
         'Content-Type' => 'application/json',

--- a/app/decorators/models/user_decorator.rb
+++ b/app/decorators/models/user_decorator.rb
@@ -226,7 +226,7 @@ User.class_eval do
         "FirstName" => first_name,
         "LastName" => last_name,
         "Email" => identity_email,
-        "PasswordResetReturnUrl" => "http://#{ENV['CANVAS_DOMAIN']}",
+        "PasswordResetReturnUrl" => "https://#{ENV['CANVAS_DOMAIN']}",
         "SendPasswordResetEmail": true
       }.to_json,
       :headers => {

--- a/app/decorators/models/user_decorator.rb
+++ b/app/decorators/models/user_decorator.rb
@@ -226,8 +226,8 @@ User.class_eval do
         "FirstName" => first_name,
         "LastName" => last_name,
         "Email" => identity_email,
-        "SendPasswordResetEmail": true,
-        "PasswordResetReturnUrl": "http://#{ENV['CANVAS_DOMAIN']}"
+        "PasswordResetReturnUrl" => "http://#{ENV['CANVAS_DOMAIN']}",
+        "SendPasswordResetEmail": true
       }.to_json,
       :headers => {
         'Content-Type' => 'application/json',


### PR DESCRIPTION
I am unable to test this in my current environment, so this may be horribly wrong. But I think this will help with some of the scenarios around users getting lost after they are created. This does depend on a bug fix being deployed in Identity (https://dev.azure.com/strongmind/Strongmind/_git/Identity/pullrequest/6942)