### PR TITLE
Behavioral: STEAK-725: added the course_progress noun publishing back

### DIFF
--- a/spec/models/context_module_progression_spec.rb
+++ b/spec/models/context_module_progression_spec.rb
@@ -22,4 +22,10 @@ describe ContextModuleProgression do
     cmp.save
   end
 
+  it 'publishes course_progress to the pipeline' do
+    cmp = ContextModuleProgression.new(user: user, context_module: context_module)
+    expect(PipelineService).to receive(:publish_as_v2).with instance_of(PipelineService::Nouns::CourseProgress)
+    cmp.save
+  end
+
 end


### PR DESCRIPTION
This commit also includes a new test to ensure that the course_progress nound indeed get published.

Closes STEAK-725