### PR TITLE
temporarily commenting out nill value entry log to sentry. alerted se…

### DIFF
--- a/app/services/pipeline_service/serializers/course.rb
+++ b/app/services/pipeline_service/serializers/course.rb
@@ -11,10 +11,10 @@ module PipelineService
         if SettingsService.get_settings(object: :school, id: 1)['powerschool_integration']
           @payload.merge!(powerschool_ids)
 
-
-          if powerschool_ids.values.any?(&:nil?)
-            Sentry.capture_message("powerschool ids has at least one null value in Noun for course #{@course}")
-          end
+          # commenting out due to overactive alerting. Not deleting in case of repurposing code next sprint
+          # if powerschool_ids.values.any?(&:nil?)
+            # Sentry.capture_message("powerschool ids has at least one null value in Noun for course #{@course}")
+          # end
         end
         @payload
       end


### PR DESCRIPTION
…ntry too aggressively to cover accurate use case.