### PR TITLE
QTY-362 truncate source in delayed jobs before save if length exceeds limit

### DIFF
--- a/app/decorators/models/delayed/job.rb
+++ b/app/decorators/models/delayed/job.rb
@@ -1,0 +1,9 @@
+Delayed::Job.class_eval do
+  before_save :truncate_source_column
+
+  def truncate_source_column
+    limit = Delayed::Job.columns_hash['source'].limit
+    puts self.source if self.source.length > limit
+    self.source = self.source[0..limit-1] if self.source.length > limit
+  end
+end


### PR DESCRIPTION
Co-authored-by: Angel Diaz <angel.diaz@strongmind.com>
Co-authored-by: Charles Parisi <charles.parisi@strongmind.com>
Co-authored-by: Christopher Adeszko <christopher.adeszko@strongmind.com>