### PR TITLE
QTY-1414: downgrade ruby back down to 2.5

### DIFF
--- a/app/assets/javascripts/canvas_shim/application.js.erb
+++ b/app/assets/javascripts/canvas_shim/application.js.erb
@@ -9,7 +9,7 @@
 //
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
-<%= (ENV['RAILS_ENV'] == 'development') ? '//= require jquery' : '//= require jquery/dist/jquery' %>
+//= require jquery
 //
 // Add some Shim asset require directives here
 // i.e.


### PR DESCRIPTION
[QTY-1413](https://strongmind.atlassian.net/browse/QTY-1413)

#Delete comments under headings and replace with appropriate descriptions for each category

## Purpose 
downgrade ruby from 2.6.10 to 2.5, there were more incompatibilities found on thursday with ruby 2.6.

## Approach 
downrade using deps and gemfile

## Testing
We rolled out this image thursday night.
