### PR TITLE
QTY-1599: Add Threshold settings for all assignment groups at the course level

### DIFF
--- a/app/assets/javascripts/canvas_shim/course_settings.js
+++ b/app/assets/javascripts/canvas_shim/course_settings.js
@@ -27,7 +27,7 @@ function confirmClear() {
 }
 
 $(window).on("load", function(event) {
-  $('#edit_passing_thresholds_btn').click(function(e) {
+  $('#edit_course_passing_thresholds_btn').click(function(e) {
     e.preventDefault();
     e.stopPropagation();
     let thresholdFields = getThresholdFields();

--- a/app/assets/javascripts/canvas_shim/course_settings.js
+++ b/app/assets/javascripts/canvas_shim/course_settings.js
@@ -27,35 +27,36 @@ function confirmClear() {
 }
 
 $(window).on("load", function(event) {
-  var initialVal = $('#passing_threshold').val();
-  $('#edit_threshold_btn').click(function(e) {
+  $('#edit_passing_thresholds_btn').click(function(e) {
     e.preventDefault();
     e.stopPropagation();
-    var passThreshDisabled = $('#passing_threshold').prop('disabled');
-    $('#passing_threshold').prop('disabled', !passThreshDisabled);
-    $("#threshold_edited").remove();
-    $(this).append("<input type='hidden' id='threshold_edited' name='threshold_edited' value=" + passThreshDisabled + " />")
-    if ($('#passing_threshold').prop('disabled')) {
-      $('#passing_threshold').val(initialVal);
-    }
+    let thresholdFields = getThresholdFields();
+    let thresholdFieldsDisabled = thresholdFields[0].disabled;
 
-    flipIcon($(this), passThreshDisabled);
+    editThresholdFields(thresholdFields, thresholdFieldsDisabled);
+
+    flipIcon($(this), thresholdFieldsDisabled);
   });
 
-  var initialUnitVal = $('#passing_unit_threshold').val();
-  $('#edit_unit_threshold_btn').click(function(e) {
-    e.preventDefault();
-    e.stopPropagation();
-    var unitPassThreshDisabled = $('#passing_unit_threshold').prop('disabled');
-    $('#passing_unit_threshold').prop('disabled', !unitPassThreshDisabled);
-    $("#unit_threshold_edited").remove();
-    $(this).append("<input type='hidden' id='unit_threshold_edited' name='unit_threshold_edited' value=" + unitPassThreshDisabled + " />")
-    if ($('#passing_unit_threshold').prop('disabled')) {
-      $('#passing_unit_threshold').val(initialUnitVal);
-    }
+  function getThresholdFields() {
+    return Array.from($('.passing-threshold-number-field'));
+  }
 
-    flipIcon($(this), unitPassThreshDisabled);
-  });
+  function editThresholdFields(thresholdFields, thresholdFieldsDisabled){
+    thresholdFields.forEach(function(el, i) {
+      var initialFieldValue = $(el).val();
+      var id_string = $(el).attr('id').split('_').slice(2).join('_');
+      var edited_id_string = id_string + "_edited";
+
+      $(el).attr('disabled', !thresholdFieldsDisabled);
+      $("#" + edited_id_string).val(thresholdFieldsDisabled);
+
+      if($("#" + id_string).prop('disabled')) {
+        $("#" + id_string).val(initialFieldValue);
+      }
+    });
+  }
+
 
   $(".endpoint-btn").click(function(e) {
     e.preventDefault();

--- a/app/decorators/controllers/accounts_controller_decorator.rb
+++ b/app/decorators/controllers/accounts_controller_decorator.rb
@@ -1,5 +1,5 @@
 AccountsController.class_eval do
-  ASSIGNMENT_GROUP_NAMES = AssignmentGroup::GROUP_NAMES.map{|n| n.downcase.gsub(/\s/, "_")}
+  ASSIGNMENT_GROUP_NAMES = AssignmentGroup.passing_threshold_group_names
 
   def show_account_by_uuid
     @account = Account.find_by(uuid: params[:account_uuid].split(":").last)

--- a/app/decorators/controllers/context_modules_controller_decorator.rb
+++ b/app/decorators/controllers/context_modules_controller_decorator.rb
@@ -62,7 +62,7 @@ ContextModulesController.class_eval do
   private
 
   def can_add_threshold_overrides?
-    RequirementsService.course_has_set_threshold?(@context) && RequirementsService.module_editing_enabled? &&
+    RequirementsService.course_has_set_threshold?(context: @context, assignment_group_names: ASSIGNMENT_GROUP_NAMES) && RequirementsService.module_editing_enabled? &&
     context_module_params[:completion_requirements] && authorized_action(@module, @current_user, :update)
   end
 

--- a/app/decorators/controllers/context_modules_controller_decorator.rb
+++ b/app/decorators/controllers/context_modules_controller_decorator.rb
@@ -37,7 +37,7 @@ ContextModulesController.class_eval do
   end
 
   def strongmind_item_redirect
-    if @context.is_a?(Course) && @context.user_is_student?(@current_user) && RequirementsService.course_has_set_threshold?(@context)
+    if @context.is_a?(Course) && @context.user_is_student?(@current_user) && RequirementsService.course_has_set_threshold?(context: @context, assignment_group_names: ASSIGNMENT_GROUP_NAMES)
       course_progress = CourseProgress.new(@context, @current_user)
       @course_progress_assignment = course_progress.try(&:current_content_tag).try(&:assignment)
       submission = @course_progress_assignment.submissions.find_by(user: @current_user) if @course_progress_assignment

--- a/app/decorators/controllers/context_modules_controller_decorator.rb
+++ b/app/decorators/controllers/context_modules_controller_decorator.rb
@@ -1,5 +1,5 @@
 ContextModulesController.class_eval do
-  ASSIGNMENT_GROUP_NAMES = AssignmentGroup::GROUP_NAMES.map{|n| n.downcase.gsub(/\s/, "_")}
+  ASSIGNMENT_GROUP_NAMES = AssignmentGroup.passing_threshold_group_names
 
   def strongmind_update
     @module = @context.context_modules.not_deleted.find(params[:id])

--- a/app/decorators/controllers/courses_controller_decorator.rb
+++ b/app/decorators/controllers/courses_controller_decorator.rb
@@ -1,6 +1,6 @@
 CoursesController.class_eval do
   helper_method :enrollment_name, :user_can_conclude_enrollments?
-  ASSIGNMENT_GROUP_NAMES = AssignmentGroup::GROUP_NAMES.map{|n| n.strip.downcase.gsub(/\s+/, '_')}
+  ASSIGNMENT_GROUP_NAMES = AssignmentGroup.passing_threshold_group_names
 
   def show_course_enrollments
     get_context

--- a/app/decorators/controllers/courses_controller_decorator.rb
+++ b/app/decorators/controllers/courses_controller_decorator.rb
@@ -103,8 +103,7 @@ CoursesController.class_eval do
 
   def strongmind_show
     instructure_show
-    score_threshold = RequirementsService.get_course_assignment_passing_threshold?(@context)
-    js_env(score_threshold: score_threshold.to_s) if score_threshold
+    js_env(passing_thresholds: RequirementsService.get_assignment_group_passing_thresholds(context: @context))
     js_env(module_editing_disabled: RequirementsService.disable_module_editing_on?)
   end
 

--- a/app/decorators/controllers/courses_controller_decorator.rb
+++ b/app/decorators/controllers/courses_controller_decorator.rb
@@ -129,6 +129,7 @@ CoursesController.class_eval do
     if course_settings_params
       if course_settings_params.keys.select{|k| k.match(/(_passing_threshold)/)}.any?
         set_assignment_group_thresholds(ASSIGNMENT_GROUP_NAMES)
+        RequirementsService.force_min_scores(course: @course, assignment_group_names: ASSIGNMENT_GROUP_NAMES)
       end  
     end
   end

--- a/app/decorators/controllers/courses_controller_decorator.rb
+++ b/app/decorators/controllers/courses_controller_decorator.rb
@@ -112,7 +112,7 @@ CoursesController.class_eval do
 
 
   def strongmind_settings
-    @expose_discussion_and_project_threshold_field = Rails.configuration.launch_darkly_client.variation("expose-discussion-and-project-threshold-field", launch_darkly_user, false)
+    @expose_course_level_passing_threshold_fields = Rails.configuration.launch_darkly_client.variation("expose-course-level-passing-threshold-fields", launch_darkly_user, false)
     @assignment_group_thresholds = get_course_thresholds(ASSIGNMENT_GROUP_NAMES)
     get_course_dates
     hide_destructive_course_options?

--- a/app/decorators/controllers/courses_controller_decorator.rb
+++ b/app/decorators/controllers/courses_controller_decorator.rb
@@ -112,9 +112,13 @@ CoursesController.class_eval do
 
 
   def strongmind_settings
+<<<<<<< HEAD
     @expose_discussion_and_project_threshold_field = Rails.configuration.launch_darkly_client.variation("expose-discussion-and-project-threshold-field", launch_darkly_user, false)
 
     get_course_threshold
+=======
+    @assignment_group_thresholds = get_course_thresholds(AssignmentGroup::GROUP_NAMES.map{|n| n.strip.downcase.gsub(/\s+/, '_')})
+>>>>>>> bc224314 (QTY-1601: Stub assignment group thresholds in course settings)
     get_course_dates
     hide_destructive_course_options?
     instructure_settings
@@ -198,6 +202,12 @@ CoursesController.class_eval do
     return unless @threshold_visible
     @course_threshold = RequirementsService.get_passing_threshold(type: :course, id: params[:course_id], assignment_group_name: nil)
     @course_exam_threshold = RequirementsService.get_passing_threshold(type: :course, id: params[:course_id], assignment_group_name: nil)
+  end
+
+  def get_course_thresholds(assignment_group_names)
+    @threshold_visible = threshold_ui_allowed?
+    return unless @threshold_visible
+    {"workbook"=>30}
   end
 
   def threshold_ui_allowed?

--- a/app/decorators/controllers/courses_controller_decorator.rb
+++ b/app/decorators/controllers/courses_controller_decorator.rb
@@ -112,13 +112,8 @@ CoursesController.class_eval do
 
 
   def strongmind_settings
-<<<<<<< HEAD
     @expose_discussion_and_project_threshold_field = Rails.configuration.launch_darkly_client.variation("expose-discussion-and-project-threshold-field", launch_darkly_user, false)
-
-    get_course_threshold
-=======
     @assignment_group_thresholds = get_course_thresholds(AssignmentGroup::GROUP_NAMES.map{|n| n.strip.downcase.gsub(/\s+/, '_')})
->>>>>>> bc224314 (QTY-1601: Stub assignment group thresholds in course settings)
     get_course_dates
     hide_destructive_course_options?
     instructure_settings

--- a/app/decorators/models/account_decorator.rb
+++ b/app/decorators/models/account_decorator.rb
@@ -4,7 +4,9 @@ Account.class_eval do
     thresholds = get_assignment_group_thresholds
     courses = self.courses.where('start_at >= ?', Time.zone.now)
     courses.each do |course|
+      overridden_group_names = get_overridden_assignment_groups(course)
       thresholds.each do |group_name, value|
+        next if !!overridden_group_names&.include?(group_name)
         RequirementsService.set_passing_threshold(
           type: 'course',
           id: course.id,
@@ -25,5 +27,9 @@ Account.class_eval do
       thresholds[group_name] = RequirementsService.get_passing_threshold(type: 'school', assignment_group_name: group_name)
     end
     thresholds
+  end
+
+  def get_overridden_assignment_groups(course)
+    SettingsService.get_settings(object: 'course', id: course.id)['assignment_group_threshold_overrides']
   end
 end

--- a/app/decorators/models/assignment_group_decorator.rb
+++ b/app/decorators/models/assignment_group_decorator.rb
@@ -2,4 +2,8 @@ AssignmentGroup.class_eval do
   after_commit -> { PipelineService.publish(self) }
 
   GROUP_NAMES = [ 'Assignment', 'Checkpoint', 'Close Reading Project', 'Discussion', 'Exam', 'Final Exam', 'Pretest', 'Project', 'Workbook' ].freeze
+
+  def self.passing_threshold_group_names
+    GROUP_NAMES.map{|n| n.downcase.gsub(/\s/, "_")}
+  end
 end

--- a/app/decorators/models/context_module_decorator.rb
+++ b/app/decorators/models/context_module_decorator.rb
@@ -4,7 +4,7 @@ ContextModule.class_eval do
 
   def assign_threshold
     if completion_requirements_was&.empty?
-      RequirementsService.apply_minimum_scores(context_module: self)
+      RequirementsService.apply_minimum_scores(context_module: self, assignment_group_names: AssignmentGroup::GROUP_NAMES.map{|n| n.strip.downcase.gsub(/\s+/, '_')})
     end
   end
 

--- a/app/decorators/models/context_module_decorator.rb
+++ b/app/decorators/models/context_module_decorator.rb
@@ -10,8 +10,10 @@ ContextModule.class_eval do
 
   def update_threshold_reqs
     passing_thresholds = SettingsService.get_settings(object: 'course', id: self.course.try(:id))
+    assignment_overrides = get_assignment_threshold_overrides
     self.completion_requirements.each do |req|
       next unless req[:type] == 'min_score'
+      next if assignment_overrides&.include?(req[:id])
       content_tag = ContentTag.find(req[:id])
       assignment_group_name = case content_tag.content_type
                               when 'DiscussionTopic'
@@ -28,4 +30,8 @@ ContextModule.class_eval do
     self.touch
   end
   handle_asynchronously :update_threshold_reqs
+
+  def get_assignment_threshold_overrides
+    SettingsService.get_settings(object: 'course', id: self.course.try(:id))['threshold_overrides']
+  end
 end

--- a/app/decorators/models/context_module_decorator.rb
+++ b/app/decorators/models/context_module_decorator.rb
@@ -4,7 +4,7 @@ ContextModule.class_eval do
 
   def assign_threshold
     if completion_requirements_was&.empty?
-      RequirementsService.apply_minimum_scores(context_module: self, assignment_group_names: AssignmentGroup::GROUP_NAMES.map{|n| n.strip.downcase.gsub(/\s+/, '_')})
+      RequirementsService.apply_minimum_scores(context_module: self, assignment_group_names: AssignmentGroup.passing_threshold_group_names)
     end
   end
 

--- a/app/decorators/models/course_decorator.rb
+++ b/app/decorators/models/course_decorator.rb
@@ -33,9 +33,9 @@ Course.class_eval do
     alias_method :default_tabs, :strongmind_default_tabs
   end
 
-  def force_min_scores
+  def force_min_scores(assignment_group_names:)
     context_modules.each do |cm|
-      RequirementsService.apply_minimum_scores(context_module: cm, force: true)
+      RequirementsService.apply_minimum_scores(context_module: cm, force: true, assignment_group_names: assignment_group_names)
     end
   end
 

--- a/app/services/pipeline_service/serializers/course.rb
+++ b/app/services/pipeline_service/serializers/course.rb
@@ -15,11 +15,7 @@ module PipelineService
       end
 
       def passing_thresholds
-        { 'passing_thresholds' => {
-            'assignment' => format_threshold(:get_course_assignment_passing_threshold?),
-            'exam' => format_threshold(:get_course_exam_passing_threshold?)
-          }
-        }
+        { 'passing_thresholds' => get_assignment_group_passing_thresholds }
       end
 
       def powerschool_ids
@@ -33,6 +29,10 @@ module PipelineService
         threshold = RequirementsService.send(method, @course)
         return nil if threshold.nil?
         threshold.to_f
+      end
+
+      def get_assignment_group_passing_thresholds
+        RequirementsService.get_assignment_group_passing_thresholds(context: @course)
       end
     end
   end

--- a/app/services/requirements_service.rb
+++ b/app/services/requirements_service.rb
@@ -1,16 +1,6 @@
 module RequirementsService
   def self.apply_minimum_scores(context_module:, force: false, assignment_group_names:)
-    # apply_assignment_min_scores(context_module: context_module, force: force)
-    # apply_unit_exam_min_scores(context_module: context_module, force: force)
     apply_assignment_group_min_scores(context_module: context_module, force: force, assignment_group_names: assignment_group_names)
-  end
-
-  def self.apply_assignment_min_scores(context_module:, force: false)
-    Commands::ApplyAssignmentMinScores.new(context_module: context_module, force: force).call
-  end
-
-  def self.apply_unit_exam_min_scores(context_module:, force: false)
-    Commands::ApplyUnitExamMinScores.new(context_module: context_module, force: force).call
   end
 
   def self.apply_assignment_group_min_scores(context_module:, force: false, assignment_group_names:)
@@ -115,8 +105,8 @@ module RequirementsService
     )
   end
 
-  def self.reset_requirements(context_module:, exam: false)
-    Commands::ResetRequirements.new(context_module: context_module, exam: exam).call
+  def self.reset_requirements(context_module:, assignment_group_name:)
+    Commands::ResetRequirements.new(context_module: context_module, assignment_group_name: assignment_group_name).call
   end
 
   def self.set_third_party_requirements(course:)

--- a/app/services/requirements_service.rb
+++ b/app/services/requirements_service.rb
@@ -69,13 +69,14 @@ module RequirementsService
   end
 
   def self.get_assignment_group_passing_thresholds(context:, assignment_group_names: AssignmentGroup.passing_threshold_group_names)
+    type = context&.class&.to_s&.downcase == 'pipelineservice::models::noun' ? context.noun_class : context&.class
     thresholds = {}
     assignment_group_names.each do |group_name|
-      thresholds[group_name] = get_passing_threshold(type: context&.class&.to_s&.downcase, id: context.try(:id), assignment_group_name: group_name).to_f
+      thresholds[group_name] = get_passing_threshold(type: type&.to_s&.downcase, id: context.try(:id), assignment_group_name: group_name).to_f
     end
     thresholds
   end
-  
+
   def self.course_has_set_threshold?(context:, assignment_group_names: assignment_group_names)
     thresholds = get_assignment_group_passing_thresholds(context: context, assignment_group_names: assignment_group_names)
     thresholds.any?

--- a/app/services/requirements_service.rb
+++ b/app/services/requirements_service.rb
@@ -9,7 +9,7 @@ module RequirementsService
     end
   end
 
-  def self.force_min_scores(course:, assignment_group_names:)
+  def self.force_min_scores(course:, assignment_group_names: AssignmentGroup::GROUP_NAMES.map{|n| n.strip.downcase.gsub(/\s+/, '_')})
     Commands::ForceMinScores.new(course: course, assignment_group_names: assignment_group_names).call
   end
 
@@ -74,10 +74,6 @@ module RequirementsService
       thresholds[group_name] = RequirementsService.get_passing_threshold(type: 'course', id: context.try(:id), assignment_group_name: group_name)
     end
     thresholds.any?
-  end
-
-  def self.is_unit_exam?(content_tag:)
-    Queries::FindUnitExam.new(content_tag: content_tag).call
   end
 
   def self.course_threshold_setting_enabled?

--- a/app/services/requirements_service/commands/apply_assignment_group_min_scores.rb
+++ b/app/services/requirements_service/commands/apply_assignment_group_min_scores.rb
@@ -95,16 +95,6 @@ module RequirementsService
                     )
         requirement.merge!(type: 'min_score', min_score: min_score)
       end
-
-      def unit_exam?(requirement)
-        content_tag = ContentTag.find_by(id: requirement[:id])
-        content_tag && RequirementsService.is_unit_exam?(content_tag: content_tag)
-      end
-
-      def not_unit_exam?(requirement)
-        !unit_exam?(requirement)
-      end
-
     end
   end
 end

--- a/app/services/requirements_service/commands/apply_assignment_group_min_scores.rb
+++ b/app/services/requirements_service/commands/apply_assignment_group_min_scores.rb
@@ -1,0 +1,103 @@
+module RequirementsService
+  module Commands
+    class ApplyAssignmentGroupMinScores
+      def initialize(context_module:, force: false, assignment_group_name:)
+        @context_module = context_module
+        @completion_requirements = context_module.completion_requirements
+        @force = force
+        @course = context_module.course
+        @settings = SettingsService.get_settings(object: :course, id: course.try(:id))
+        @setting_name = "#{assignment_group_name}_passing_threshold"
+        @threshold_exists = !!settings["#{@setting_name}"]
+        @score_threshold = settings["#{setting_name}"].to_f
+        @threshold_overrides = settings['threshold_overrides']
+      end
+
+      def call
+        binding.pry
+        return unless threshold_exists
+
+        if force
+          RequirementsService.strip_overrides(course) if threshold_overrides
+        else
+          return unless threshold_changes_needed?
+        end
+
+        run_command
+      end
+
+      private
+
+      attr_reader :completion_requirements, :context_module, :course, :force, :score_threshold, :threshold_overrides, :settings, :threshold_exists
+
+      def run_command
+        if score_threshold.zero?
+          reset_requirements
+        else
+          add_min_score_to_requirements
+          finalize_update
+        end
+      end
+
+      def reset_requirements
+        RequirementsService.reset_requirements(context_module: context_module)
+      end
+
+      def finalize_update
+        context_module.update_column(:completion_requirements, completion_requirements)
+        context_module.touch
+      end
+
+      def threshold_changes_needed?
+        return false unless score_threshold.positive?
+        completion_requirements.any? do |req|
+          is_submittable?(req) || (min_score_different_than_threshold?(req) && not_unit_exam?(req))
+        end
+      end
+
+      def is_submittable?(req)
+        ["must_submit", "must_contribute"].include?(req[:type])
+      end
+
+      def min_score_different_than_threshold?(req)
+        (req[:min_score] && req[:min_score] != score_threshold)
+      end
+    
+      def has_threshold_override?(requirement)
+        threshold_overrides.split(",").map(&:to_i).include?(requirement[:id]) if threshold_overrides
+      end
+
+      def skippable_requirement?(requirement)
+        has_threshold_override?(requirement) ||
+        ["must_submit", "must_contribute", "min_score"].none? { |type| type == requirement[:type] } ||
+        unit_exam?(requirement)
+      end
+    
+      def add_min_score_to_requirements
+        completion_requirements.each do |requirement|
+          next if skippable_requirement?(requirement)
+          update_score(requirement)
+        end
+      end
+    
+      def update_score(requirement)
+        content_tag = ContentTag.find_by(id: requirement[:id])
+        min_score = RequirementsService.percentify_min_score(
+                      content_tag: content_tag,
+                      passing_threshold: score_threshold
+                    )
+        requirement.merge!(type: 'min_score', min_score: min_score)
+      end
+
+      def unit_exam?(requirement)
+        content_tag = ContentTag.find_by(id: requirement[:id])
+        content_tag && RequirementsService.is_unit_exam?(content_tag: content_tag)
+      end
+
+      def not_unit_exam?(requirement)
+        !unit_exam?(requirement)
+      end
+
+    end
+  end
+end

--- a/app/services/requirements_service/commands/apply_assignment_group_min_scores.rb
+++ b/app/services/requirements_service/commands/apply_assignment_group_min_scores.rb
@@ -22,7 +22,6 @@ module RequirementsService
         else
           return unless threshold_changes_needed?
         end
-
         run_command
       end
 
@@ -62,7 +61,7 @@ module RequirementsService
       def min_score_different_than_threshold?(req)
         (req[:min_score] && req[:min_score] != score_threshold)
       end
-    
+
       def has_threshold_override?(requirement)
         threshold_overrides.split(",").map(&:to_i).include?(requirement[:id]) if threshold_overrides
       end
@@ -86,7 +85,7 @@ module RequirementsService
           update_score(requirement)
         end
       end
-    
+
       def update_score(requirement)
         content_tag = ContentTag.find_by(id: requirement[:id])
         min_score = RequirementsService.percentify_min_score(

--- a/app/services/requirements_service/commands/force_min_scores.rb
+++ b/app/services/requirements_service/commands/force_min_scores.rb
@@ -1,8 +1,9 @@
 module RequirementsService
   module Commands
     class ForceMinScores
-      def initialize(course:)
+      def initialize(course:, assignment_group_names:)
         @course = course
+        @assignment_group_names = assignment_group_names
       end
 
       def call
@@ -10,7 +11,7 @@ module RequirementsService
       end
 
       def perform
-        @course.try(:force_min_scores)
+        @course.try(:force_min_scores, assignment_group_names: @assignment_group_names)
       end
     end
   end

--- a/app/services/requirements_service/commands/reset_requirements.rb
+++ b/app/services/requirements_service/commands/reset_requirements.rb
@@ -22,6 +22,7 @@ module RequirementsService
 
       def reset_requirements
         completion_requirements.each do |requirement|
+          next if skippable_requirement?(requirement)
           reset_individual_requirement(requirement)
         end
       end

--- a/app/services/requirements_service/commands/reset_requirements.rb
+++ b/app/services/requirements_service/commands/reset_requirements.rb
@@ -1,10 +1,10 @@
 module RequirementsService
   module Commands
     class ResetRequirements
-      def initialize(context_module:, exam: false)
+      def initialize(context_module:, assignment_group_name:)
         @context_module = context_module
         @completion_requirements = context_module.completion_requirements
-        @exam = exam
+        @assignment_group_name = assignment_group_name
       end
 
       def call
@@ -13,7 +13,7 @@ module RequirementsService
       end
 
       private
-      attr_reader :context_module, :completion_requirements, :exam
+      attr_reader :context_module, :completion_requirements, :exam, :assignment_group_name
 
       def update_completion_requirements
         context_module.update_column(:completion_requirements, completion_requirements)
@@ -22,14 +22,22 @@ module RequirementsService
 
       def reset_requirements
         completion_requirements.each do |requirement|
-          next if skippable_requirement?(requirement)
           reset_individual_requirement(requirement)
-        end  
+        end
       end
         
       def reset_individual_requirement(requirement)
         content_tag = get_content_tag(requirement)
         return unless content_tag
+        passing_threshold_group_name = case content_tag.content_type
+          when 'DiscussionTopic'
+            content_tag.content.assignment.passing_threshold_group_name
+          when 'Assignment'
+            content_tag.content.passing_threshold_group_name
+          else
+            return
+          end
+        return unless passing_threshold_group_name == assignment_group_name
         requirement.delete(:min_score)
         requirement.merge!(type: requirement_type(content_tag))
       end
@@ -45,12 +53,6 @@ module RequirementsService
 
       def skippable_requirement?(req)
         return true unless req[:min_score]
-        @exam ? !unit_exam?(req) : unit_exam?(req)
-      end
-
-      def unit_exam?(requirement)
-        content_tag = get_content_tag(requirement)
-        content_tag && RequirementsService.is_unit_exam?(content_tag: content_tag)
       end
 
       def get_content_tag(requirement)

--- a/app/services/requirements_service/commands/set_school_thresholds_on_course.rb
+++ b/app/services/requirements_service/commands/set_school_thresholds_on_course.rb
@@ -1,7 +1,7 @@
 module RequirementsService
   module Commands
     class SetSchoolThresholdsOnCourse
-      ASSIGNMENT_GROUP_NAMES = AssignmentGroup::GROUP_NAMES.map{|n| n.downcase.gsub(/\s/, "_")}
+      ASSIGNMENT_GROUP_NAMES = AssignmentGroup.passing_threshold_group_names
 
       def initialize(course:)
         @course = course

--- a/app/views/courses/_assignment_groups_thresholds.html.erb
+++ b/app/views/courses/_assignment_groups_thresholds.html.erb
@@ -11,8 +11,6 @@
                                 :placeholder => "Choose a number between 0-100",
                                 :disabled => true %>
       <%= hidden_field_tag "#{group_name}_passing_threshold_edited", false %>
-      <p style="font-size: 0.9em;"><%= t("Set a school-wide minimum percentage for all #{group_name.humanize.downcase.pluralize}. Each of these #{group_name.humanize.downcase.pluralize} will have an adjusted minimum score based on this percentage.") %></p>
-      <p style="font-size: 0.9em;"><%= t("This setting is off by default, and/or when the threshold is set to 0.0.") %></p>
     </td>
   </tr><tr>
 <% end %>

--- a/app/views/courses/_assignment_groups_thresholds.html.erb
+++ b/app/views/courses/_assignment_groups_thresholds.html.erb
@@ -1,0 +1,18 @@
+<% @assignment_group_thresholds.each do |group_name, threshold| %>
+  </tr><tr>
+    <td><%= settings.blabel "#{group_name}_passing_threshold".to_sym, :en => "#{group_name.humanize.pluralize}" %></td>
+    <td>
+      <%= settings.number_field "#{group_name}_passing_threshold".to_sym,
+                                :value => threshold,
+                                :class => 'same-width-as-select, passing-threshold-number-field',
+                                :min => "0",
+                                :max => "100",
+                                :step => "0.1",
+                                :placeholder => "Choose a number between 0-100",
+                                :disabled => true %>
+      <%= hidden_field_tag "#{group_name}_passing_threshold_edited", false %>
+      <p style="font-size: 0.9em;"><%= t("Set a school-wide minimum percentage for all #{group_name.humanize.downcase.pluralize}. Each of these #{group_name.humanize.downcase.pluralize} will have an adjusted minimum score based on this percentage.") %></p>
+      <p style="font-size: 0.9em;"><%= t("This setting is off by default, and/or when the threshold is set to 0.0.") %></p>
+    </td>
+  </tr><tr>
+<% end %>

--- a/app/views/courses/settings.html.erb
+++ b/app/views/courses/settings.html.erb
@@ -276,40 +276,26 @@
 
       <% end %>
 
-      <% if @threshold_visible %>
-        </tr><tr>
-          <td class="form-label"><label for="passing_threshold" id="passing_threshold_label"><%= t("Passing Threshold (Assignments):") %></label></td>
-          <td class="tall-row">
-            <div>
-              <input type="number" name="passing_threshold" id="passing_threshold" placeholder="Number b/w 0-100" value="<%= @course_threshold %>" min="0" max="100" step="0.1" style="width: 50px;" disabled />
-              <a id="edit_threshold_btn" href="" class="Button Button--icon-action">
+      <% if @threshold_visible && true %>
+      </tr><tr>
+        <td colspan="2">
+          <fieldset>
+            <legend><%= t(:passing_threshold_settings, 'Passing Threshold Settings') %>
+              <a id="edit_passing_thresholds_btn" class="Button Button--icon-action">
                 <i class="icon-edit"></i>
               </a>
-            </div>
-
-            <div class="aside palign">
-              <p><%= t("Set a course-wide minimum percentage for all graded assignments. Each assignment will have an adjusted minimum score based on this percentage.") %></p>
-              <p><%= t('Adjusting this setting will override the score set by the administrator and any previously changed module settings.') %></p>
-              <p><%= t('Restoring the score to 0.0 turns the threshold off.') %></p>
-            </div>
-          </td>
-
-        </tr><tr>
-          <td class="form-label"><label for="passing_unit_threshold" id="passing_unit_threshold_label"><%= t("Passing Threshold (Exams):") %></label></td>
-          <td class="tall-row">
-            <div>
-              <input type="number" name="passing_unit_threshold" id="passing_unit_threshold" placeholder="Number b/w 0-100" value="<%= @course_exam_threshold %>" min="0" max="100" step="0.1" style="width: 50px;" disabled />
-              <a id="edit_unit_threshold_btn" href="" class="Button Button--icon-action">
-                <i class="icon-edit"></i>
-              </a>
-            </div>
-
-            <div class="aside palign">
-              <p><%= t("Set a course-wide minimum percentage for all unit/final exams. Each of these exams will have an adjusted minimum score based on this percentage.") %></p>
-              <p><%= t('Adjusting this setting will override the score set by the administrator and any previously changed module settings.') %></p>
-              <p><%= t('Restoring the score to 0.0 turns the threshold off.') %></p>
-            </div>
-          </td>
+            </legend>
+          </fieldset>
+        </td>
+        <%= f.fields_for :settings do |settings| %>
+          <%= render partial: "assignment_groups_thresholds", locals: {settings: settings} %>
+        <% end %>
+      </tr>
+      <tr>
+        <td colspan="2">
+          <hr>
+        </td>
+      </tr><tr>
       <% end %>
       
       <% if available_locales.size > 1 %>

--- a/app/views/courses/settings.html.erb
+++ b/app/views/courses/settings.html.erb
@@ -276,7 +276,7 @@
 
       <% end %>
 
-      <% if @threshold_visible && true %>
+      <% if @threshold_visible && @expose_course_level_passing_threshold_fields %>
       </tr><tr>
         <td colspan="2">
           <fieldset>

--- a/app/views/courses/settings.html.erb
+++ b/app/views/courses/settings.html.erb
@@ -281,7 +281,7 @@
         <td colspan="2">
           <fieldset>
             <legend><%= t(:passing_threshold_settings, 'Passing Threshold Settings') %>
-              <a id="edit_passing_thresholds_btn" class="Button Button--icon-action">
+              <a id="edit_course_passing_thresholds_btn" class="Button Button--icon-action">
                 <i class="icon-edit"></i>
               </a>
             </legend>

--- a/spec/services/pipeline_service/serializers/course_spec.rb
+++ b/spec/services/pipeline_service/serializers/course_spec.rb
@@ -8,21 +8,37 @@ describe PipelineService::Serializers::Course do
 
     before do
       allow(SettingsService).to receive(:get_settings).and_return({
-        'passing_threshold' => 50,
-        'passing_exam_threshold' => 50,
         'powerschool_integration' => true,
         'powerschool_course_id' => 254
+      })
+      allow(RequirementsService).to receive(:get_assignment_group_passing_thresholds).and_return({
+        "assignment"=>10.0, 
+        "checkpoint"=>20.0, 
+        "close_reading_project"=>30.0, 
+        "discussion"=>40.0, 
+        "exam"=>50.0, 
+        "final_exam"=>60.0, 
+        "pretest"=>70.0, 
+        "project"=>80.0, 
+        "workbook"=>90.0
       })
 
       allow(IdentifierMapperService::Client).to receive(:get_powerschool_school_id).and_return(452)
     end
 
-    it 'Return an attribute hash of the noun', :skip => 'serializer functionality to be updated' do
+    it 'Return an attribute hash of the noun' do
       expect(subject.call).to include({
         noun.primary_key => active_record_object.id,
         'passing_thresholds' => {
-          "assignment"=>50.0,
-          "exam"=>50.0
+          "assignment"=>10.0, 
+          "checkpoint"=>20.0, 
+          "close_reading_project"=>30.0, 
+          "discussion"=>40.0, 
+          "exam"=>50.0, 
+          "final_exam"=>60.0, 
+          "pretest"=>70.0, 
+          "project"=>80.0, 
+          "workbook"=>90.0
         }
       })
     end
@@ -43,18 +59,34 @@ describe PipelineService::Serializers::Course do
 
     before do
       allow(SettingsService).to receive(:get_settings).and_return({
-        'passing_threshold' => 50,
-        'passing_exam_threshold' => 50,
         'powerschool_integration' => false
+      })
+      allow(RequirementsService).to receive(:get_assignment_group_passing_thresholds).and_return({
+        "assignment"=>10.0, 
+        "checkpoint"=>20.0, 
+        "close_reading_project"=>30.0, 
+        "discussion"=>40.0, 
+        "exam"=>50.0, 
+        "final_exam"=>60.0, 
+        "pretest"=>70.0, 
+        "project"=>80.0, 
+        "workbook"=>90.0
       })
     end
 
-    it 'Return an attribute hash of the noun', :skip => 'serializer functionality to be updated' do
+    it 'Return an attribute hash of the noun' do
       expect(subject.call).to include({
         noun.primary_key => active_record_object.id,
         'passing_thresholds' => {
-          "assignment"=>50.0,
-          "exam"=>50.0
+          "assignment"=>10.0, 
+          "checkpoint"=>20.0, 
+          "close_reading_project"=>30.0, 
+          "discussion"=>40.0, 
+          "exam"=>50.0, 
+          "final_exam"=>60.0, 
+          "pretest"=>70.0, 
+          "project"=>80.0, 
+          "workbook"=>90.0
         }
       })
     end

--- a/spec/services/requirements_service/reset_requirements_spec.rb
+++ b/spec/services/requirements_service/reset_requirements_spec.rb
@@ -1,8 +1,8 @@
 describe RequirementsService::Commands::ResetRequirements do
   include_context 'stubbed_network'
-  subject { described_class.new(context_module: context_module) }
+  let(:subject) { described_class.new(context_module: context_module, assignment_group_name: content_tags[1].content.passing_threshold_group_name) }
   
-  let(:subject_2) { described_class.new(context_module: context_module, exam: true) }
+  let(:subject_2) { described_class.new(context_module: context_module, assignment_group_name: content_tags[3].content.assignment.passing_threshold_group_name) }
   
   let(:course) { double('course', id: 1) }
   
@@ -16,59 +16,38 @@ describe RequirementsService::Commands::ResetRequirements do
     ) 
   end
 
+  let(:content_tags) do
+    tags = FactoryBot.create_list(:content_tag, 3, :with_assignment, context_id: course.id, context_type: "course")
+    tags << FactoryBot.create(:content_tag, :with_discussion_topic, context_id: course.id, context_type: 'course')
+  end
+
   let(:completion_requirements) do
+    content_tags[0].content.assignment_group.update(name: "workbooks")
+    content_tags[1].content.assignment_group.update(name: "exams")
+    content_tags[2].content.assignment_group.update(name: "assignment")
+    content_tags[3].content.assignment.assignment_group.update(name: "discussion")
     [
-      {:id=>53, :type=>"must_view"},
-      {:id=>56, :type=>"min_score", :min_score => 70},
-      unit_exam
+      {:id=>content_tags[0].id, :type=>"must_view"},
+      {:id=>content_tags[1].id, :type=>"must_submit"},
+      {:id=>content_tags[2].id, :type=>"must_contribute"},
+      {:id=>content_tags[3].id, :type=>"min_score", :min_score=>69.0}
     ]
   end
 
-  let(:unit_exam) do
-    {:id=>58, :type=>"min_score", :min_score => 75}
-  end
-
-  before do
-    ContentTag.create(id: 56)
-    allow(subject).to receive(:unit_exam?).and_call_original
-    allow(subject).to receive(:unit_exam?).with(unit_exam).and_return(true)
-  end
-
   describe "#call" do
-    it "skips the unit exam" do
-      subject.call
-      req_scores = context_module.completion_requirements.select { |req| req[:min_score] }
-      expect(req_scores.size).to eq(1)
-      expect(req_scores.first[:min_score]).to eq(75)
-    end
-
     it "converts to a must_submit" do
       subject.call
       expect(context_module.completion_requirements[1][:type]).to eq("must_submit")
     end
 
-    
     context "DiscussionTopic" do
       before do
-        ContentTag.find(56).update(content_type: "DiscussionTopic")
+        content_tags[3].update(content_type: "DiscussionTopic")
       end
 
       it "Turns to a must contribute when content_type is DiscussionTopic" do
-        subject.call
-        expect(context_module.completion_requirements[1][:type]).to eq("must_contribute")
-      end
-    end
-
-    context "Unit Exam" do
-      before do
-        content_tag = ContentTag.create(id: 58)
-        allow(RequirementsService).to receive(:is_unit_exam?).and_call_original
-        allow(RequirementsService).to receive(:is_unit_exam?).with(content_tag: content_tag).and_return(true)
-      end
-
-      it "converts the unit exam" do
         subject_2.call
-        expect(context_module.completion_requirements[2][:type]).to eq("must_submit")
+        expect(context_module.completion_requirements[3][:type]).to eq("must_contribute")
       end
     end
   end

--- a/spec/services/requirements_service_spec.rb
+++ b/spec/services/requirements_service_spec.rb
@@ -6,6 +6,7 @@ describe RequirementsService do
   let(:requirements) { double('requirements') }
   let(:content_tag) { double('content_tag') }
   let(:command_instance) { double('command instance') }
+  let(:assignment_group_names) { ["assignment", "checkpoint", "close_reading_project", "discussion", "exam", "final_exam", "pretest", "project", "workbook"] }
 
   before do
     allow(command_class).to receive(:new).and_return(command_instance)
@@ -13,17 +14,26 @@ describe RequirementsService do
   end
   
   describe '#apply_minimum_scores' do
-    let(:command_class) { RequirementsService::Commands::ApplyAssignmentMinScores }
+    let(:command_class) { RequirementsService::Commands::ApplyAssignmentGroupMinScores }
 
     it 'Calls the command object' do
       expect(command_instance).to receive(:call)
-      subject.apply_assignment_min_scores(context_module: context_module)
+      subject.apply_assignment_group_min_scores(context_module: context_module, assignment_group_names: assignment_group_names)
     end
 
     context "stripping overrides" do
       it 'accepts a strip overrides parameter' do
-        expect(command_class).to receive(:new).with(context_module: context_module, force: true)
-        subject.apply_assignment_min_scores(context_module: context_module, force: true)
+        expect(command_class).to receive(:new).with(context_module: context_module, force: true, assignment_group_name: assignment_group_names[0])
+        expect(command_class).to receive(:new).with(context_module: context_module, force: true, assignment_group_name: assignment_group_names[1])
+        expect(command_class).to receive(:new).with(context_module: context_module, force: true, assignment_group_name: assignment_group_names[2])
+        expect(command_class).to receive(:new).with(context_module: context_module, force: true, assignment_group_name: assignment_group_names[3])
+        expect(command_class).to receive(:new).with(context_module: context_module, force: true, assignment_group_name: assignment_group_names[4])
+        expect(command_class).to receive(:new).with(context_module: context_module, force: true, assignment_group_name: assignment_group_names[5])
+        expect(command_class).to receive(:new).with(context_module: context_module, force: true, assignment_group_name: assignment_group_names[6])
+        expect(command_class).to receive(:new).with(context_module: context_module, force: true, assignment_group_name: assignment_group_names[7])
+        expect(command_class).to receive(:new).with(context_module: context_module, force: true, assignment_group_name: assignment_group_names[8])
+
+        subject.apply_assignment_group_min_scores(context_module: context_module, force: true, assignment_group_names: assignment_group_names)
       end
     end
   end

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -2,4 +2,32 @@ FactoryBot.define do
   factory :context_module_progression do
     collapsed true
   end
+
+  factory :course do
+  end
+
+  factory :content_tag do
+    trait :with_assignment do 
+      association :content, factory: [:assignment, :with_assignment_group]
+    end
+
+    trait :with_discussion_topic do
+      association :content, factory: [:discussion_topic, :with_assignment]
+    end
+  end
+
+  factory :assignment do
+    trait :with_assignment_group do
+      association :assignment_group, factory: :assignment_group
+    end
+  end
+
+  factory :assignment_group do
+  end
+
+  factory :discussion_topic do
+    trait :with_assignment do
+      association :assignment, factory: [:assignment, :with_assignment_group]
+    end
+  end
 end


### PR DESCRIPTION
[QTY-1599](https://strongmind.atlassian.net/browse/QTY-1599)

## Purpose 

Allow school personnel to set passing thresholds at the course-level, which take precedence over the account-level passing thresholds (added by [this PR](https://github.com/StrongMind/canvas_shim/pull/412)), if set. 

## Approach 

Update course settings page to have fields for a pre-determined set of assignment groups, replacing the existing threshold fields for assignments and exams.

Utilize AssignmentGroup::GROUP_NAMES constant added by the previous PR to determine which assignment groups we will support passing thresholds for by default.

Utilizes the existing RequirementsService and SettingsService to dynamically get and set thresholds for the supported assignment groups.

Updates the checks in `context_modules_controller_decorator.rb` to check for thresholds for the newly supported groups at the course level.

Updates `courses_controller_decorator.rb` to get/set thresholds at the course level for the newly supported assignment groups. Adds some helper methods (`determine_assignment_group_overrides` and `set_assignment_group_threshold_overrides`) to determine which assignment groups have been overridden at the course level and set an additional setting on the course, `assignment_group_threshold_overrides`, so that it is not overridden by an account level update. 

Updates the callback in `account_decorator.rb`, `context_module_decorator.rb` to respect the course level assignment group overrides. 

Adds a helper method for the assignment group names in `assignment_group_decorator.rb`

Updates to the `requirements_service`, `force_min_scores` to respect assignment group name thresholds. 

Updates the `course` pipeline serializer to pass all of the new assignment group thresholds data to the pipeline.

Adds `apply_assignment_group_min_scores` class (based on the previously used `apply_assignment_min_scores` and `apply_unit_exam_min_scores` to handle much of the logic for determining how and when thresholds are updated. 

Remove references to `unit_exam` as they are no longer handled as a special case. 

Update existing specs to be in line with new functionality. Added a couple of factories to support testing. 

## Testing

Tested locally and on newidsandbox. To confirm thresholds are set and updated as expected some example steps might be:

1. Set thresholds on account settings page
2. Create a new course and import a cartridge, verify that the thresholds set are applied to the course settings page and assignments based on the content's assignment group
3. Edit an assignments assignment group, verify that the threshold changed as appropriate
4. Edit the course level thresholds, verify that content within the course has threshold updated as appropriate
5. Manually create an assignment and a discussion topic (since they are created differently) and verify that both have the appropriate thresholds set (DiscussionTopic will not have a threshold set until marked as graded as that is when it has an associated assignment created and therefor an assignment group threshold to associate)
6. Create courses with a start date in the past and one in the future
7. Change the thresholds set in account settings
8. Verify that the course with a past start date is not affected but the course with the future start date reflects the new thresholds
9. Verify that courses which have passing thresholds overridden are not affected by the change at the account level but that course level thresholds which match the account level setting are updated. 

## Screenshots/Video

<img width="1269" alt="image" src="https://user-images.githubusercontent.com/30609917/208202575-ab10fd97-15f2-47aa-b576-f67af44bb764.png">

