### PR TITLE
QTY-passing-thresholds-nil-object-fix

### DIFF
--- a/app/decorators/controllers/courses_controller_decorator.rb
+++ b/app/decorators/controllers/courses_controller_decorator.rb
@@ -103,7 +103,10 @@ CoursesController.class_eval do
 
   def strongmind_show
     instructure_show
-    js_env(passing_thresholds: RequirementsService.get_assignment_group_passing_thresholds(context: @context))
+    if @context
+      passing_thresholds = RequirementsService.get_assignment_group_passing_thresholds(context: @context) 
+    end
+    js_env(passing_thresholds: passing_thresholds) if passing_thresholds
     js_env(module_editing_disabled: RequirementsService.disable_module_editing_on?)
   end
 


### PR DESCRIPTION
Co-authored-by: Angel Diaz <angel.diaz@strongmind.com>

- Check for context before requirements service call to get passing thresholds for course
- Check for passing thresholds before attempting to set js_env

## Purpose 

Following a recent deployment, we saw a large number for Sentry errors coming due to a nil Object error. This change aims to silence those exceptions. 

## Approach 

This change adds a checks for `@context` and `passing_thresholds` existence before attempting to call the `RequirementsService` and subsequently add the resulting thresholds into `js_env`

## Testing

Verified the affected page, `Courses#show`, still loads as expected locally and in production and no new Sentry errors appeared when hitting the affected routes. 
