### PR TITLE
QTY-1741: update rpsec.yml to install bundler 2.3.25

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -49,7 +49,7 @@ jobs:
           SETTINGS_TABLE_PREFIX: settings
         run: |
           sudo apt-get -yqq install libpq-dev
-          gem install bundler
+          gem install bundler:2.3.25
           bundle install --jobs 4 --retry 3
           bundle exec rails db:setup
           bundle exec rspec


### PR DESCRIPTION
[QTY-1741]()

## Purpose 
looks like we we're installing the latest version of bundler in the github actions test box, version locked it to mach our gemfile

## Approach 
updated rspec.yml

## Testing
manually run rpsec github action



[QTY-1741]: https://strongmind.atlassian.net/browse/QTY-1741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ