### PR TITLE
QTY-1459 Create alert for when a Guided Practice is submitted

### DIFF
--- a/app/services/alerts_service/alerts/guided_practice_submitted.rb
+++ b/app/services/alerts_service/alerts/guided_practice_submitted.rb
@@ -1,0 +1,27 @@
+module AlertsService
+  module Alerts
+    class GuidedPracticeSubmitted < Alert
+      ALERT_ATTRIBUTES = %i{ teacher_id student_id assignment_id course_id}
+
+      def initialize(atts)
+        super
+      end
+
+      def assignment
+        Assignment.find(assignment_id)
+      end
+
+      def student
+        User.find(student_id)
+      end
+
+      def detail
+        "Guided Practice Submitted"
+      end
+
+      def description
+        'Guided Practice Submitted'
+      end
+    end
+  end
+end

--- a/spec/decorators/models/submission_spec.rb
+++ b/spec/decorators/models/submission_spec.rb
@@ -33,6 +33,27 @@ describe Submission do
           submission.update(submitted_at: Time.now)
         end
       end
+
+      context 'when the assignment is not a Guided Practice' do
+        it "should not call #send_guided_practice_alert" do
+          assignment = content_tag.content
+          assignment.update(course_id: course.id)
+          assignment.assignment_group.update(name: 'Not Guided Practice')
+          submission = Submission.new(user: student, assignment: assignment)
+          expect(submission).not_to receive(:send_guided_practice_submitted_alert)
+          submission.update(submitted_at: Time.now)
+        end
+
+        it "should not create a new AlertService::Client instance" do
+          assignment = content_tag.content
+          assignment.update(course_id: course.id)
+          assignment.assignment_group.update(name: 'Not Guided Practice')
+          course.enrollments.concat([teacher_enrollment, student_enrollment])
+          submission = Submission.new(user: student, assignment: assignment)
+          expect(AlertsService::Client).not_to receive(:create).with(:guided_practice_submitted, teacher_id: teacher.id, student_id: student.id, assignment_id: assignment.id, course_id: course.id)
+          submission.update(submitted_at: Time.now)
+        end
+      end
     end
   end
 end

--- a/spec/decorators/models/submission_spec.rb
+++ b/spec/decorators/models/submission_spec.rb
@@ -1,0 +1,38 @@
+describe Submission do
+  subject { described_class }
+  include_context 'stubbed_network'
+  
+  let(:subject_instance) { double('subject_instance')}
+  
+  # before do
+  #   allow(subject).to receive(:new).and_return(subject_instance)
+  #   allow(subject_instance).to receive(:save)
+  #   allow(subject_instance).to receive(:send_guided_practice_submitted_alert)
+  # end
+  
+  describe 'callbacks' do
+    describe 'send_guided_practice_submitted_alert' do
+      let(:course) { create(:course) }
+      let(:teacher) { create(:user) }
+      let(:student) { create(:user) }
+      let(:content_tag) { create(:content_tag, :with_assignment)}
+      let(:teacher_enrollment) { create(:enrollment, user: teacher, course: course, type: 'TeacherEnrollment') }
+      let(:student_enrollment) { create(:enrollment, user: student, course: course, type: 'StudentEnrollment') }
+      
+      it "should alert the teacher when a student submits a guided practice" do
+        assignment = content_tag.content
+        assignment.assignment_group.update(name: 'Guided Practice')
+        alert_instance = instance_double(AlertsService::Client)
+        allow(AlertsService::Client).to receive(:create).and_return(alert_instance)
+        submission = Submission.new(user: student, assignment: assignment)
+        binding.pry
+        expect(submission).to receive(:send_guided_practice_submitted_alert)
+        submission.save
+        # expect(alert_instance).to have_received(:create).with(:guided_practice_submitted, teacher.id, student.id, assignment.id, course.id)
+        # expect(subject_instance).to receive(:send_guided_practice_submitted_alert)
+        # subject.create(user: student, assignment: assignment, course: course, workflow_state: 'submitted')
+      end
+
+    end
+  end
+end

--- a/spec/decorators/models/submission_spec.rb
+++ b/spec/decorators/models/submission_spec.rb
@@ -4,14 +4,8 @@ describe Submission do
   
   let(:subject_instance) { double('subject_instance')}
   
-  # before do
-  #   allow(subject).to receive(:new).and_return(subject_instance)
-  #   allow(subject_instance).to receive(:save)
-  #   allow(subject_instance).to receive(:send_guided_practice_submitted_alert)
-  # end
-  
   describe 'callbacks' do
-    describe 'send_guided_practice_submitted_alert' do
+    describe '#send_guided_practice_submitted_alert' do
       let(:course) { create(:course) }
       let(:teacher) { create(:user) }
       let(:student) { create(:user) }
@@ -19,20 +13,26 @@ describe Submission do
       let(:teacher_enrollment) { create(:enrollment, user: teacher, course: course, type: 'TeacherEnrollment') }
       let(:student_enrollment) { create(:enrollment, user: student, course: course, type: 'StudentEnrollment') }
       
-      it "should alert the teacher when a student submits a guided practice" do
-        assignment = content_tag.content
-        assignment.assignment_group.update(name: 'Guided Practice')
-        alert_instance = instance_double(AlertsService::Client)
-        allow(AlertsService::Client).to receive(:create).and_return(alert_instance)
-        submission = Submission.new(user: student, assignment: assignment)
-        binding.pry
-        expect(submission).to receive(:send_guided_practice_submitted_alert)
-        submission.save
-        # expect(alert_instance).to have_received(:create).with(:guided_practice_submitted, teacher.id, student.id, assignment.id, course.id)
-        # expect(subject_instance).to receive(:send_guided_practice_submitted_alert)
-        # subject.create(user: student, assignment: assignment, course: course, workflow_state: 'submitted')
-      end
+      context 'when the assignment is a Guided Practice' do 
+        it "should call #send_guided_practice_alert" do
+          assignment = content_tag.content
+          assignment.update(course_id: course.id)
+          assignment.assignment_group.update(name: 'Guided Practice')
+          submission = Submission.new(user: student, assignment: assignment)
+          expect(submission).to receive(:send_guided_practice_submitted_alert)
+          submission.update(submitted_at: Time.now)
+        end
 
+        it "should create a new AlertService::Client instance" do
+          assignment = content_tag.content
+          assignment.update(course_id: course.id)
+          assignment.assignment_group.update(name: 'Guided Practice')
+          course.enrollments.concat([teacher_enrollment, student_enrollment])
+          submission = Submission.new(user: student, assignment: assignment)
+          expect(AlertsService::Client).to receive(:create).with(:guided_practice_submitted, teacher_id: teacher.id, student_id: student.id, assignment_id: assignment.id, course_id: course.id)
+          submission.update(submitted_at: Time.now)
+        end
+      end
     end
   end
 end

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -1,6 +1,6 @@
 describe Assignment do
   include_context "stubbed_network"
-  let(:assignment) { Assignment.create }
+  let(:assignment) { create(:assignment, :with_assignment_group)}
   let(:user) { User.create }
   let(:submission) { Submission.create(assignment: assignment, user: user, excused: nil) }
   let(:user_2) { User.create }
@@ -40,7 +40,7 @@ describe Assignment do
   describe "when saved" do
     it "publishes to pipeline" do
       expect(PipelineService).to receive(:publish_as_v2)
-      Assignment.create
+      create(:assignment, :with_assignment_group) 
     end
   end
 end

--- a/spec/models/course_progress_spec.rb
+++ b/spec/models/course_progress_spec.rb
@@ -46,8 +46,8 @@ describe CourseProgress do
 
   describe "#requirement_count" do
     context "with excused submission" do
-      let(:assn) { Assignment.create(course_id: course.id) }
-      let(:assn_2) { Assignment.create(course_id: course.id) }
+      let(:assn) { create(:assignment, :with_assignment_group, course_id: course.id) }
+      let(:assn_2) { create(:assignment, :with_assignment_group, course_id: course.id) }
       let!(:sub) { Submission.create(assignment: assn, user: user) }
       let(:excused_sub) { Submission.create(assignment: assn_2, user: user, context_code: "course_#{course.id}") }
       let(:content_tag_1) { ContentTag.create }

--- a/spec/models/student_enrollment_spec.rb
+++ b/spec/models/student_enrollment_spec.rb
@@ -2,7 +2,7 @@ describe StudentEnrollment do
   include_context "stubbed_network"
   let!(:course) { Course.create }
   let!(:user) { User.create }
-  let!(:assignment) { Assignment.create(course: course) }
+  let!(:assignment) { create(:assignment, :with_assignment_group, course: course) }
   let!(:submission) do 
     Submission.create(
       assignment: assignment,
@@ -48,7 +48,7 @@ describe StudentEnrollment do
 
   describe "#missing_assignments_count" do
     context "deleted assignment" do
-      let!(:assignment) { Assignment.create(course: course, workflow_state: "deleted") }
+      let!(:assignment) { create(:assignment, :with_assignment_group, course: course, workflow_state: "deleted") }
 
       let!(:submission) do
         Submission.create(
@@ -66,7 +66,7 @@ describe StudentEnrollment do
     end
 
     context "unpublished assignment" do
-      let!(:assignment) { Assignment.create(course: course, workflow_state: "unpublished") }
+      let!(:assignment) { create(:assignment, :with_assignment_group, course: course, workflow_state: "unpublished") }
 
       let!(:submission) do
         Submission.create(
@@ -84,7 +84,7 @@ describe StudentEnrollment do
     end
 
     context "past due and unsubmitted" do
-      let!(:assignment) { Assignment.create(course: course, workflow_state: "published") }
+      let!(:assignment) { create(:assignment, :with_assignment_group, course: course, workflow_state: "published") }
 
       let!(:submission) do 
         Submission.create(
@@ -102,7 +102,7 @@ describe StudentEnrollment do
     end
 
     context "Zero graded" do
-      let!(:assignment) { Assignment.create(course: course, workflow_state: "published") }
+      let!(:assignment) { create(:assignment, :with_assignment_group, course: course, workflow_state: "published") }
 
       let!(:submission) do 
         Submission.create(

--- a/spec/models/submission_comment_spec.rb
+++ b/spec/models/submission_comment_spec.rb
@@ -5,7 +5,7 @@ describe SubmissionComment do
     let(:course) { Course.create(users: [teacher, student]) }
     let(:teacher) { User.create }
     let(:student) { User.create }
-    let(:assignment) { Assignment.create(course: course) }
+    let(:assignment) { create(:assignment, :with_assignment_group, course: course) }
     let(:submission) { Submission.create(user: student, assignment: assignment) }
     let(:teacher_enrollments) { course.enrollments.where(user: teacher) }
     let(:student_enrollments) { course.enrollments.where(user: student) }

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -7,7 +7,7 @@ describe Submission do
     end
 
     context "V2 Submissions" do
-      let(:assignment) { Assignment.create }
+      let(:assignment) { create(:assignment, :with_assignment_group) }
 
       describe '#send_submission_to_pipeline' do
         before do
@@ -45,7 +45,7 @@ describe Submission do
     let!(:submission) { Submission.create(score: 30, assignment: assignment, excused: true) }
     let!(:submission2) { Submission.create(score: 30, assignment: assignment, excused: true) }
 
-    let(:assignment) { Assignment.new }
+    let(:assignment) { create(:assignment, :with_assignment_group) }
     let(:teacher) { User.create }
 
     it "records a comment when the excused tag is removed" do
@@ -65,7 +65,7 @@ context "Submission Needs Regrading" do
 
     let!(:course) { Course.create() }
     let!(:teacher_enrollment) { TeacherEnrollment.create(course: course, user: teacher) }
-    let!(:assignment) { Assignment.new(course: course) }
+    let!(:assignment) { create(:assignment, :with_assignment_group, course: course) }
     let!(:teacher) { User.create() }
 
     it "sends an alert when a zero graded submission is submitted" do

--- a/spec/services/alerts_service/alerts/guided_practice_submitted_spec.rb
+++ b/spec/services/alerts_service/alerts/guided_practice_submitted_spec.rb
@@ -1,0 +1,72 @@
+describe AlertsService::Alerts::GuidedPracticeSubmitted do
+  subject {
+    described_class.new(
+      teacher_id: 1,
+      student_id: 2,
+      assignment_id: 3,
+      course_id: 10,
+      created_at: datetime,
+      updated_at: updated_datetime
+    )
+  }
+
+  let(:datetime) { '2019-06-13 20:53:14.153693+00:00' }
+  let(:updated_datetime) { '2019-06-13 20:58:14.153693+00:00' }
+  let(:json_response) { subject.as_json }
+
+  before do
+    ENV['ALERT_SERVICE_SCHOOL_NAME'] = 'test.strongmind.com'
+  end
+
+  describe '#created_at' do
+    it 'is in the right format' do
+      expect(subject.created_at).to eq(DateTime.parse(datetime))
+    end
+  end
+
+  describe '#type' do
+    it do
+      expect(subject.type).to eq("guided_practice_submitted")
+    end
+  end
+
+  describe '#updated_at' do
+    it 'is in the right format' do
+      expect(subject.updated_at).to eq(DateTime.parse(updated_datetime))
+    end
+  end
+
+  describe '#detail' do
+    it 'has the correct detail' do
+      expect(subject.detail).to eq "Guided Practice Submitted"
+    end
+  end
+
+  describe '#as_json' do
+    it 'teacher_id' do
+      expect(json_response[:teacher_id]).to eq 1
+    end
+
+    it 'student_id' do
+      expect(json_response[:student_id]).to eq 2
+    end
+
+    it 'assignment_id' do
+      expect(json_response[:assignment_id]).to eq 3
+    end
+
+    it 'type' do
+      expect(json_response[:type]).to eq 'guided_practice_submitted'
+    end
+
+    it 'description' do
+      expect(json_response[:description]).to eq 'Guided Practice Submitted'
+    end
+
+    it 'course_id' do
+      expect(json_response[:course_id]).to eq 10
+    end
+
+  end
+
+end

--- a/spec/services/assignments_service/commands/set_enrollment_assignment_due_dates_spec.rb
+++ b/spec/services/assignments_service/commands/set_enrollment_assignment_due_dates_spec.rb
@@ -19,8 +19,8 @@ describe AssignmentsService::Commands::SetEnrollmentAssignmentDueDates do
     )
   end
 
-  let(:assignment) { Assignment.create(submissions: [submission], due_at: Time.now) }
-  let(:assignment2) { Assignment.create(submissions: [submission2], due_at: Time.now) }
+  let(:assignment) { create(:assignment, :with_assignment_group, submissions: [submission], due_at: Time.now) }
+  let(:assignment2) { create(:assignment, :with_assignment_group, submissions: [submission2], due_at: Time.now) }
 
   before do
     allow(PipelineService).to receive(:publish)
@@ -94,8 +94,8 @@ describe AssignmentsService::Commands::SetEnrollmentAssignmentDueDates do
       end
 
       context 'assignment has no due date' do
-        let(:assignment) { Assignment.create(submissions: [submission]) }
-        let(:assignment2) { Assignment.create(submissions: [submission2]) }
+          let(:assignment) { create(:assignment, :with_assignment_group, submissions: [submission]) }
+          let(:assignment2) { create(:assignment, :with_assignment_group, submissions: [submission2]) }
 
         it 'wont run' do
           expect(AssignmentOverrideStudent).to_not receive(:create)

--- a/spec/services/grades_service/queries/zero_grader_submissions_spec.rb
+++ b/spec/services/grades_service/queries/zero_grader_submissions_spec.rb
@@ -5,7 +5,7 @@ describe GradesService::Queries::ZeroGraderSubmissions do
   describe '#submissions_scope' do
     it 'Will query after the course' do
       course = Course.create(conclude_at: 2.hours.ago)
-      assignment = Assignment.create(course: course, due_at: 1.day.ago, workflow_state: 'published')
+      assignment = create(:assignment, :with_assignment_group, course: course, due_at: 1.day.ago, workflow_state: 'published')
       submission = Submission.create(assignment: assignment,
           workflow_state: 'unsubmitted',
           score: nil,

--- a/spec/services/pipeline_service/V2/nouns/submission_spec.rb
+++ b/spec/services/pipeline_service/V2/nouns/submission_spec.rb
@@ -3,7 +3,7 @@ describe PipelineService::V2::Nouns::Submission do
   
     subject { described_class.new(object: noun) }
   
-    let(:active_record_object) { ::Submission.create!(assignment: Assignment.create!(course: Course.create)) }
+    let(:active_record_object) { ::Submission.create!(assignment: create(:assignment, :with_assignment_group, course: Course.create)) }
   
     let(:noun) { PipelineService::V2::Noun.new(active_record_object)}
   

--- a/spec/services/pipeline_service/V2/payload_spec.rb
+++ b/spec/services/pipeline_service/V2/payload_spec.rb
@@ -2,7 +2,7 @@ describe PipelineService::V2::Payload do
   include_context 'stubbed_network'
   let(:course) { Course.create() }
   let(:user) { User.create() }
-  let(:assignment) { Assignment.create(course: course) }
+  let(:assignment) { create(:assignment, :with_assignment_group, course: course) }
   let(:submission) { Submission.create(assignment: assignment, user: user) }
 
 

--- a/spec/services/pipeline_service/models/noun_spec.rb
+++ b/spec/services/pipeline_service/models/noun_spec.rb
@@ -5,7 +5,7 @@ describe PipelineService::Models::Noun do
     let(:submission) { Submission.create(assignment: assignment, user: user) }
     let(:submission_noun) { described_class.new(submission) }
     let(:course) { Course.create }
-    let(:assignment) { Assignment.create(course: course) }
+    let(:assignment) { create(:assignment, :with_assignment_group, course: course) }
     let(:deleted_conversation) { Conversation.create() }
     let(:teacher_enrollment) { TeacherEnrollment.new }
     let(:teacher_enrollment_noun) { described_class.new(teacher_enrollment)}

--- a/spec/services/pipeline_service/serializers/submission_spec.rb
+++ b/spec/services/pipeline_service/serializers/submission_spec.rb
@@ -39,7 +39,7 @@ describe PipelineService::Serializers::Submission do
 
   let(:headers) { { Authorization: "Bearer #{ENV['STRONGMIND_INTEGRATION_KEY']}" } }
   let(:course) { Course.create }
-  let(:assignment) { Assignment.create(course: course) }
+  let(:assignment) { create(:assignment, :with_assignment_group, course: course) }
   let(:user) { User.create }
   let(:submission) { Submission.create(submitted_at: Time.now, assignment: assignment, user: user) }
   let(:integration_key) { rand.to_s }

--- a/spec/services/pipeline_service/serializers/unit_grades_spec.rb
+++ b/spec/services/pipeline_service/serializers/unit_grades_spec.rb
@@ -5,7 +5,7 @@ describe PipelineService::Serializers::UnitGrades do
     context 'when given a submission' do
       subject { described_class.new(object: unit_grades)}
 
-      let(:assignment) { Assignment.create(course: course) }
+      let(:assignment) { create(:assignment, :with_assignment_group, course: course) }
       let(:course) { Course.create }
       let(:pseudonym) { Pseudonym.create }
       let(:student) { User.create(pseudonym: pseudonym) }

--- a/spec/services/units_service/commands/get_unit_grades_spec.rb
+++ b/spec/services/units_service/commands/get_unit_grades_spec.rb
@@ -71,7 +71,7 @@ describe UnitsService::Commands::GetUnitGrades do
   context "#unit_excused?" do
     let!(:course) {Course.create()}
     let!(:cm) {ContextModule.create(position: 3, course: course)}
-    let!(:assignment) { Assignment.create(workflow_state: 'active', course: course)}
+    let!(:assignment) { create(:assignment, :with_assignment_group, workflow_state: 'active', course: course)}
     let!(:content_tag) { ContentTag.create(context_module: cm, assignment: assignment, content_type: 'Assignment', content_id: assignment.id) }
     let!(:submission) { Submission.create(grader_id: 2, submitted_at: current_time, user: user, assignment: assignment) }
 
@@ -86,8 +86,8 @@ describe UnitsService::Commands::GetUnitGrades do
 
     it 'returns false if not all are excused' do
       cm = ContextModule.create()
-      assignment = Assignment.create(workflow_state: 'active')
-      assignment_2 = Assignment.create(workflow_state: 'active')
+      assignment = create(:assignment, :with_assignment_group, workflow_state: 'active')
+      assignment_2 = create(:assignment, :with_assignment_group, workflow_state: 'active')
 
       content_tag = ContentTag.create(context_module: cm, assignment: assignment, content_type: 'Assignment', content_id: assignment.id)
       content_tag_2 = ContentTag.create(context_module: cm, assignment: assignment_2, content_type: 'Assignment', content_id: assignment.id)

--- a/spec/services/units_service/queries/get_submissions_spec.rb
+++ b/spec/services/units_service/queries/get_submissions_spec.rb
@@ -3,7 +3,7 @@ describe UnitsService::Queries::GetSubmissions do
   let(:student) { User.create }
   let(:course)  { Course.create(context_modules: [unit]) }
   let(:submission) { Submission.create!(user: student, assignment: assignment) }
-  let(:assignment) { Assignment.create(course: course, published: true) }
+  let(:assignment) { create(:assignment, :with_assignment_group, course: course, published: true) }
   let(:unit) { ContextModule.create }
   let(:item) { ContentTag.create(content: assignment) }
 
@@ -23,7 +23,7 @@ describe UnitsService::Queries::GetSubmissions do
     let!(:discussion_course) { Course.create(context_modules: [discussion_context_module]) }
     let!(:discussion_topic) { DiscussionTopic.create(workflow_state: 'active') }
     let!(:discussion_context_module) { ContextModule.create(content_tags: [discussion_content_tag]) }
-    let!(:discussion_assignment) { Assignment.create(discussion_topic: discussion_topic, workflow_state: 'published') }
+    let!(:discussion_assignment) { create(:assignment, :with_assignment_group, discussion_topic: discussion_topic, workflow_state: 'published') }
     let!(:discussion_submission) { Submission.create!(user: student, assignment: discussion_assignment) }
     let!(:discussion_content_tag) { ContentTag.create(content: discussion_topic) }
 

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -3,7 +3,13 @@ FactoryBot.define do
     collapsed true
   end
 
+  factory :user do
+  end
+
   factory :course do
+  end
+
+  factory :enrollment do
   end
 
   factory :content_tag do


### PR DESCRIPTION
[QTY-1459](https://strongmind.atlassian.net/browse/QTY-1459)

## Purpose 
Teachers would like to be alerted when a student submits a Guided Practice to be graded.

## Approach 
As the alerts foundation has already been laid out, our strategy was to build upon that foundation. We created the alert attributes, then utilized the submission_decorator to add our logic to have the AlertsService::Client create our alert. We configured the alert to be sent when it is the proper Assignment Group name of 'Guided Practice', and also checked to make sure that it was submitted. 

## Testing

### Steps to reproduce
- Create a course
- Have a teacher and a student both apart of that course
- Have the student submit an assignment that is apart of the 'Guided Practice' Assignment Group
- Verify that the teacher has received an alert of submission on their dashboard.

On the backend, we created tests to verify that the alert was created and sent upon a 'Guided Practice' submission. We also created tests for the inverse of that, to make sure that no alerts were created if the assignment group was not 'Guided Practice'.

Along the way of creating these tests, we modified several other tests to adjust and expect an Assignment Group. 

## Screenshots/Video

https://user-images.githubusercontent.com/44770511/212416320-5636d92c-4c20-4d06-9e57-82d632f53f66.mov




[QTY-1459]: https://strongmind.atlassian.net/browse/QTY-1459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ