### PR TITLE
QTY-1802

### DIFF
--- a/app/decorators/controllers/accounts_controller_decorator.rb
+++ b/app/decorators/controllers/accounts_controller_decorator.rb
@@ -33,9 +33,9 @@ AccountsController.class_eval do
 
     @module_editing_disabled = RequirementsService.disable_module_editing_on?
 
-    @expose_first_and_last_assignment_due_date_field = Rails.configuration.launch_darkly_client.variation("expose-first-and-last-assignment-due-date-field", launch_darkly_user, false)
-    @expose_discussion_and_project_threshold_field = Rails.configuration.launch_darkly_client.variation("expose-discussion-and-project-threshold-field", launch_darkly_user, false)
-    @expose_default_course_access_times = Rails.configuration.launch_darkly_client.variation("expose-default-course-access-times", launch_darkly_user, false)
+    @expose_first_and_last_assignment_due_date_field = Rails.configuration.launch_darkly_client.variation("expose-first-and-last-assignment-due-date-field", @launch_darkly_user, false)
+    @expose_discussion_and_project_threshold_field = Rails.configuration.launch_darkly_client.variation("expose-discussion-and-project-threshold-field", @launch_darkly_user, false)
+    @expose_default_course_access_times = Rails.configuration.launch_darkly_client.variation("expose-default-course-access-times", @launch_darkly_user, false)
 
     js_env({
       HOLIDAYS: @holidays,

--- a/app/decorators/controllers/courses_controller_decorator.rb
+++ b/app/decorators/controllers/courses_controller_decorator.rb
@@ -114,7 +114,7 @@ CoursesController.class_eval do
 
 
   def strongmind_settings
-    @expose_course_level_passing_threshold_fields = Rails.configuration.launch_darkly_client.variation("expose-course-level-passing-threshold-fields", launch_darkly_user, false)
+    @expose_course_level_passing_threshold_fields = Rails.configuration.launch_darkly_client.variation("expose-course-level-passing-threshold-fields", @launch_darkly_user, false)
     @assignment_group_thresholds = get_course_thresholds(passing_threshold_group_names)
     get_course_dates
     hide_destructive_course_options?

--- a/app/decorators/models/submission_decorator.rb
+++ b/app/decorators/models/submission_decorator.rb
@@ -113,6 +113,6 @@ Submission.class_eval do
 
   def expose_guided_practice_submission_alerts
     return true if Rails.env.development? || Rails.env.test?
-    Rails.configuration.launch_darkly_client.variation("expose-guided-practice-submitted-alerts", launch_darkly_user, false)
+    Rails.configuration.launch_darkly_client.variation("expose-guided-practice-submitted-alerts", @launch_darkly_user, false)
   end
 end


### PR DESCRIPTION
[QTY-1802](https://strongmind.atlassian.net/browse/QTY-1802)

## Purpose 
Alerts for submission of a guided practice were recently released to enterprise canvas without a launch darkly flag. In order to gradually roll out the feature to end users, we created a launch darkly flag and updated the source code to use the flag for guided practice submitted alerts. 

## Approach 
Created flag for `expose-guided-practice-submitted-alerts` in launch darkly. Added the `expose_guided_practice_submission_alerts` to `submission_decorator.rb`. Called the new `expose_guided_practice_submission_alerts` in the proc for the `after_save` callback to determine the condition of the feature flag before creating an alert. 

## Testing
- With feature flag off:
1. As a student, create a guided practice submission for a course
2. As the teacher for that course, confirm that no `guided practice submitted` alert was created and appearing in the dashboard. 
- With feature flag on:
1. As a student, create a guided practice submission for a course
2. As the teacher for that course, confirm that a `guided practice submitted` alert was created and appearing in the dashboard. 

[QTY-1802]: https://strongmind.atlassian.net/browse/QTY-1802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ