### PR TITLE
QTY-1504 prevent cheating for graded discussion topics when user must post before viewing all posts

### DIFF
--- a/app/decorators/models/discussion_topic_decorator.rb
+++ b/app/decorators/models/discussion_topic_decorator.rb
@@ -4,4 +4,8 @@ DiscussionTopic.class_eval do
   def is_excused?(user)
     self&.assignment&.is_excused?(user)
   end
+
+  def graded_discussion?
+    self.root_topic.nil? && self.type.nil? && self.threaded? && self.assignment.present?
+  end
 end

--- a/app/decorators/models/discussion_topic_decorator.rb
+++ b/app/decorators/models/discussion_topic_decorator.rb
@@ -6,6 +6,6 @@ DiscussionTopic.class_eval do
   end
 
   def graded_discussion?
-    self.root_topic.nil? && self.type.nil? && self.threaded? && self.assignment.present?
+    self.root_topic.nil? && self.type.nil? && self.assignment.present?
   end
 end

--- a/app/decorators/models/materialized_view_decorator.rb
+++ b/app/decorators/models/materialized_view_decorator.rb
@@ -1,0 +1,28 @@
+DiscussionTopic::MaterializedView.class_eval do
+  def strongmind_materialized_view_json(opts = {})
+    graded_discussion = self.discussion_topic.graded_discussion?
+    opts[:show_other_users_submissions] = false
+    entry_ids = nil
+    if graded_discussion
+      student_submission_graded = self.discussion_topic.assignment.submissions.graded.where(user_id: opts[:user_id]).any?
+      if student_submission_graded
+        opts[:show_other_users_submissions] = true
+        entry_ids = self.entry_ids_array
+      else 
+        entries = self.discussion_topic.discussion_entries.where(user_id: opts[:user_id])
+        entry_ids = entries.pluck(:id)
+        ungraded_json_structure = discussion_entry_api_json(entries, discussion_topic.context, nil, nil, [])
+      end
+    else
+      entry_ids = self.entry_ids_array
+    end
+    # binding.pry
+
+    opts[:entry_ids] = entry_ids
+    opts[:json_structure] = ungraded_json_structure.present? ? ungraded_json_structure.to_json : self.json_structure
+    instructure_materialized_view_json(opts)
+  end
+
+  alias_method :instructure_materialized_view_json, :materialized_view_json
+  alias_method :materialized_view_json, :strongmind_materialized_view_json
+end

--- a/app/decorators/models/materialized_view_decorator.rb
+++ b/app/decorators/models/materialized_view_decorator.rb
@@ -3,12 +3,12 @@ DiscussionTopic::MaterializedView.class_eval do
     graded_discussion = self.discussion_topic.graded_discussion?
     opts[:show_other_users_submissions] = false
     entry_ids = nil
-    if graded_discussion
+    if graded_discussion && launch_darkly_render_discussion_entries
       student_submission_graded = self.discussion_topic.assignment.submissions.graded.where(user_id: opts[:user_id]).any?
       if student_submission_graded
         opts[:show_other_users_submissions] = true
         entry_ids = self.entry_ids_array
-      else 
+      else
         entries = self.discussion_topic.discussion_entries.where(user_id: opts[:user_id])
         entry_ids = entries.pluck(:id)
         ungraded_json_structure = discussion_entry_api_json(entries, discussion_topic.context, nil, nil, [])
@@ -16,7 +16,6 @@ DiscussionTopic::MaterializedView.class_eval do
     else
       entry_ids = self.entry_ids_array
     end
-    # binding.pry
 
     opts[:entry_ids] = entry_ids
     opts[:json_structure] = ungraded_json_structure.present? ? ungraded_json_structure.to_json : self.json_structure
@@ -25,4 +24,9 @@ DiscussionTopic::MaterializedView.class_eval do
 
   alias_method :instructure_materialized_view_json, :materialized_view_json
   alias_method :materialized_view_json, :strongmind_materialized_view_json
+
+  def launch_darkly_render_discussion_entries
+    return true if Rails.env.development? || Rails.env.test?
+    Rails.configuration.launch_darkly_client.variation("prevent_rendering_of_discussion_board_responses_until_the_student_has_received_a_grade", @launch_darkly_user, false)
+  end
 end

--- a/spec/test_app/app/models/discussion_topic/materialized_view.rb
+++ b/spec/test_app/app/models/discussion_topic/materialized_view.rb
@@ -1,0 +1,29 @@
+class DiscussionTopic::MaterializedView < ActiveRecord::Base
+  def materialized_view_json(opts = {})
+    if !up_to_date?
+      update_materialized_view
+    end
+    
+    json_structure ||= opts[:json_structure]
+    entry_ids ||= opts[:entry_ids]
+
+    if json_structure.present?
+      participant_ids = self.participants_array
+
+      if opts[:include_new_entries] && opts[:show_other_users_submissions]
+        @for_mobile = true if opts[:include_mobile_overrides]
+
+        new_entries = all_entries.count != entry_ids.count ? all_entries.where.not(:id => entry_ids).to_a : []
+        participant_ids = (Set.new(participant_ids) + new_entries.map(&:user_id).compact + new_entries.map(&:editor_id).compact).to_a
+        entry_ids = (Set.new(entry_ids) + new_entries.map(&:id)).to_a
+        new_entries_json_structure = discussion_entry_api_json(new_entries, discussion_topic.context, nil, nil, [])
+      else
+        new_entries_json_structure = []
+      end
+
+      return json_structure, participant_ids, entry_ids, new_entries_json_structure
+    else
+      return nil
+    end
+  end
+end


### PR DESCRIPTION
[QTY-1504](https://strongmind.atlassian.net/browse/QTY-1504)

## Purpose 
Discussion topics have an optional setting that prevents students from viewing posts until they have contributed to the thread. Before this change, students were bypassing this by posting garbage values as a post, viewing other student's posts, and cheating off of their peers. To prevent cheating, we've updated this setting to not only require students to contribute, but to receive a grade for their post, before they can view their peer's contributions (this sits behind a launch darkly flag).

## Approach 
We extended the **materialized_view.rb** by adding a decorator **materialized_view_decorator.rb** which will prevent posts from rendering unless the student viewing the discussion topic has posted and that post has been graded. These checks only run for graded discussions topics (graded discussion check was added to **discussion_topic_decorator.rb**). The original functionality will be maintained for discussion topics that aren't graded. New functionality sits behind launch darkly flag (**expose-discussion-entries-only-if-graded-submission-exists**).

## Testing
We tested this both locally and in new-id-sandbox, testing that the expected behavior below was true:

When launch darkly flag is ON:
- Admin/teacher can still view all posts in discussion
- Student who has submitted a post that hasn't been graded **cannot** view other posts
- Student who has submitted a post that has been graded **can** view other posts
- Student who hasn't submitted anything **cannot** view other posts

When launch darkly flag is OFF:
- Admin/teacher can still view all posts in discussion
- Student who has submitted a post, graded or not, **can** view other posts
- Students who haven't submitted anything **cannot** view other posts

## Screenshots/Video
Nothing has changed in the UI, but our new functionality (additional checks for cheating) will happen if the following discussion board settings are checked and the launch darkly flag is on.

<img width="421" alt="image" src="https://user-images.githubusercontent.com/87540376/215540834-2e9bfb70-926d-44df-9fed-3672e9911054.png">

[QTY-1504]: https://strongmind.atlassian.net/browse/QTY-1504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Demo Video:

https://user-images.githubusercontent.com/87540376/215614391-741787ba-674a-4c2b-978e-6895af27824b.mov


