### PR TITLE
QTY-1807

### DIFF
--- a/app/decorators/models/context_module_progression_decorator.rb
+++ b/app/decorators/models/context_module_progression_decorator.rb
@@ -42,7 +42,7 @@ ContextModuleProgression.class_eval do
   def sequence_control_on?
     enrollment = StudentEnrollment.active.where(user_id: user.id, course_id: context_module.context.id).first
     settings = enrollment ? SettingsService.get_enrollment_settings(id: enrollment.id) : {}
-    if Account.first.name == 'Primavera Online High School' || "iSucceed Virtual High School"
+    if Account.first.name == 'Primavera Online High School'
       false
     else
       settings.fetch('sequence_control', true)

--- a/app/decorators/models/context_module_progression_decorator.rb
+++ b/app/decorators/models/context_module_progression_decorator.rb
@@ -42,7 +42,7 @@ ContextModuleProgression.class_eval do
   def sequence_control_on?
     enrollment = StudentEnrollment.active.where(user_id: user.id, course_id: context_module.context.id).first
     settings = enrollment ? SettingsService.get_enrollment_settings(id: enrollment.id) : {}
-    if Account.first.name == 'Primavera Online High School'
+    if Account.first.name == 'Primavera Online High School' || "iSucceed Virtual High School"
       false
     else
       settings.fetch('sequence_control', true)

--- a/app/decorators/models/context_module_progression_decorator.rb
+++ b/app/decorators/models/context_module_progression_decorator.rb
@@ -42,11 +42,7 @@ ContextModuleProgression.class_eval do
   def sequence_control_on?
     enrollment = StudentEnrollment.active.where(user_id: user.id, course_id: context_module.context.id).first
     settings = enrollment ? SettingsService.get_enrollment_settings(id: enrollment.id) : {}
-    if Account.first.name == 'Primavera Online High School'
-      false
-    else
-      settings.fetch('sequence_control', true)
-    end
+    settings.fetch('sequence_control', true)
   end
 
 end

--- a/app/decorators/models/context_module_progression_decorator.rb
+++ b/app/decorators/models/context_module_progression_decorator.rb
@@ -42,7 +42,11 @@ ContextModuleProgression.class_eval do
   def sequence_control_on?
     enrollment = StudentEnrollment.active.where(user_id: user.id, course_id: context_module.context.id).first
     settings = enrollment ? SettingsService.get_enrollment_settings(id: enrollment.id) : {}
-    settings.fetch('sequence_control', true)
+    if Account.first.name == 'Primavera Online High School'
+      false
+    else
+      settings.fetch('sequence_control', true)
+    end
   end
 
 end

--- a/app/decorators/models/submission_decorator.rb
+++ b/app/decorators/models/submission_decorator.rb
@@ -7,7 +7,7 @@ Submission.class_eval do
 
   after_update :record_excused_removed
   after_save :send_unit_grades_to_pipeline
-  after_save :send_guided_practice_submitted_alert, if: Proc.new { |submission| submission.assignment.assignment_group_name == 'Guided Practice' && submission.assignment.present? && submitted_at_changed? && expose_guided_practice_submission_alerts }
+  after_save :send_guided_practice_submitted_alert, if: Proc.new { |submission| submission.assignment.present? && submission.assignment.assignment_group_name == 'Guided Practice' && submitted_at_changed? && expose_guided_practice_submission_alerts }
 
   def send_unit_grades_to_pipeline
     return unless enable_unit_grade_calculations?

--- a/app/decorators/models/submission_decorator.rb
+++ b/app/decorators/models/submission_decorator.rb
@@ -7,7 +7,7 @@ Submission.class_eval do
 
   after_update :record_excused_removed
   after_save :send_unit_grades_to_pipeline
-  after_save :send_guided_practice_submitted_alert, if: Proc.new { |submission| expose_guided_practice_submission_alerts && submission.assignment.present? && submission.assignment.assignment_group_name == 'Guided Practice' && submitted_at_changed? }
+  after_save :send_guided_practice_submitted_alert, if: Proc.new { |submission| submission.assignment.assignment_group_name == 'Guided Practice' && submission.assignment.present? && submitted_at_changed? && expose_guided_practice_submission_alerts }
 
   def send_unit_grades_to_pipeline
     return unless enable_unit_grade_calculations?


### PR DESCRIPTION
[QTY-1807](https://strongmind.atlassian.net/browse/QTY-1807)

## Purpose 
Schools experienced an outage beginning with PrimaveraHS where delayed jobs were failing to process and were backing up the queue. As a result, students were unable to progress through their courses. We found the cause of the problem to revolve largely around Launch Darkly, its configuration, and the process of it streaming data back to LD causing mutex locks in the database which in turn force workers to restart, orphaning delayed jobs. When large amounts of submissions were being processed, an `after_safe` callback on submissions was causing repeated calls to LD, causing the issue. 

## Approach 
Refactor an `after_save` callback to check the condition of the requisite Launch Darkly flag last, so that fewer calls are made to the service. 

## Testing
There's not a way to test this locally in an effective manner. After making the change, we deployed to multiple schools that were affected and observed fewer sentry errors and **much** faster processing of delayed jobs with far fewer failures to process. We removed all temporary fixes from the codebase and saw no further evidence the problem was persisting. 


[QTY-1807]: https://strongmind.atlassian.net/browse/QTY-1807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ