### PR TITLE
QTY-2067: Remove pipeline service calls when in development

### DIFF
--- a/app/services/pipeline_service/V2/api/publish.rb
+++ b/app/services/pipeline_service/V2/api/publish.rb
@@ -7,6 +7,12 @@ module PipelineService
         end
 
         def call
+          @disable_pipeline = Rails.cache.read('disable_pipeline')
+          if @disable_pipeline.nil?
+            @disable_pipeline = SettingsService.get_settings(object: 'school', id: 1)['disable_pipeline']
+            Rails.cache.write('disable_pipeline', @disable_pipeline, expires_in: 1.hour)
+          end
+          return if @disable_pipeline
           @noun = Noun.new(@model)
           @payload = Payload.new(
             object: @noun


### PR DESCRIPTION
[QTY-2067](https://strongmind.atlassian.net/browse/QTY-2067)

## Purpose 
When working in our development environment, we are receiving errors regarding making calls to the pipeline service. As we typically don't utilize the pipeline service in our dev environment, turning off the setting will alleviate this issue.

## Approach 
The logic was already partially implemented throughout Canvas. We just needed to complete it by changing the setting and utilize Rails cache to make the calls vs. calling the db.

## Testing
Create a course while watching your logs, the error should no longer appear. In addition, tested on newidsandbox and it is still working as expected.

[QTY-2067]: https://strongmind.atlassian.net/browse/QTY-2067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ