### PR TITLE
QTY-1617

### DIFF
--- a/app/decorators/controllers/courses_controller_decorator.rb
+++ b/app/decorators/controllers/courses_controller_decorator.rb
@@ -134,6 +134,9 @@ CoursesController.class_eval do
         set_assignment_group_threshold_overrides(thresholds_to_update['override_group_names'])
         set_assignment_group_thresholds(assignment_group_names)
         RequirementsService.force_min_scores(course: @course, assignment_group_names: assignment_group_names)
+        if assignment_group_names.any?
+          json['context_module']['relock_warning'] = true
+        end
       end
     end
   end

--- a/app/decorators/controllers/courses_controller_decorator.rb
+++ b/app/decorators/controllers/courses_controller_decorator.rb
@@ -183,6 +183,19 @@ CoursesController.class_eval do
     AssignmentGroup.passing_threshold_group_names
   end
 
+  def relock
+    @course = Course.find_by(id: params[:course_id])
+    course_modules = @course.context_modules
+    course_modules.each do |course_module|
+      course_module.relock_progressions
+    end
+
+    respond_to do |format|
+      format.html { redirect_to course_settings_url }
+      format.json { render :json => {} }
+    end
+  end
+
   private
 
   def grade_out_users_params
@@ -339,7 +352,7 @@ CoursesController.class_eval do
   def course_settings_params
     params[:course][:settings]
   end
-  
+
   def clean_up_session_keys
     session.delete(:relock_warning) if session[:relock_warning].present?
   end

--- a/app/decorators/controllers/courses_controller_decorator.rb
+++ b/app/decorators/controllers/courses_controller_decorator.rb
@@ -118,7 +118,10 @@ CoursesController.class_eval do
     @assignment_group_thresholds = get_course_thresholds(passing_threshold_group_names)
     get_course_dates
     hide_destructive_course_options?
+    # puts "*****SETTINGS: #{session[:relock_warning]}*****
+    js_env(relock_warning: session[:relock_warning])
     instructure_settings
+    # binding.pry
   end
 
   alias_method :instructure_settings, :settings
@@ -127,6 +130,9 @@ CoursesController.class_eval do
   def strongmind_update
     instructure_update
     return if params[:course].blank?
+    session[:relock_warning] = false
+    # puts "*****UPDATE: #{session[:relock_warning]}*****"
+    # binding.pry
     if course_settings_params
       if course_settings_params.keys.select{|k| k.match(/(_passing_threshold)/)}.any?
         thresholds_to_update = determine_assignment_group_overrides
@@ -134,9 +140,8 @@ CoursesController.class_eval do
         set_assignment_group_threshold_overrides(thresholds_to_update['override_group_names'])
         set_assignment_group_thresholds(assignment_group_names)
         RequirementsService.force_min_scores(course: @course, assignment_group_names: assignment_group_names)
-        if assignment_group_names.any?
-          json['context_module']['relock_warning'] = true
-        end
+        session[:relock_warning] = true
+        puts "*****PARAMS UPDATE: #{session[:relock_warning]}*****"
       end
     end
   end

--- a/app/decorators/controllers/courses_controller_decorator.rb
+++ b/app/decorators/controllers/courses_controller_decorator.rb
@@ -185,10 +185,7 @@ CoursesController.class_eval do
 
   def relock
     @course = Course.find_by(id: params[:course_id])
-    course_modules = @course.context_modules
-    course_modules.each do |course_module|
-      course_module.relock_progressions
-    end
+    @course.relock
 
     respond_to do |format|
       format.html { redirect_to course_settings_url }

--- a/app/decorators/models/course_decorator.rb
+++ b/app/decorators/models/course_decorator.rb
@@ -10,7 +10,6 @@ Course.class_eval do
 
   after_commit -> { PipelineService.publish_as_v2(self) }
   after_create -> { RequirementsService.set_school_thresholds_on_course(course: self) }
-  after_save :relock_warning_check
 
   TAB_SNAPSHOT = 18
 
@@ -150,14 +149,6 @@ Course.class_eval do
     end
   end
   handle_asynchronously :update_context_module_completion_reqs
-
-  def relock_warning_check
-    # @relock_warning = session[:relock_warning]
-  end
-
-  def relock_warning?
-    @relock_warning
-  end
 
   private
   def filtered_announcements(filter)

--- a/app/decorators/models/course_decorator.rb
+++ b/app/decorators/models/course_decorator.rb
@@ -10,6 +10,7 @@ Course.class_eval do
 
   after_commit -> { PipelineService.publish_as_v2(self) }
   after_create -> { RequirementsService.set_school_thresholds_on_course(course: self) }
+  after_save :relock_warning_check
 
   TAB_SNAPSHOT = 18
 
@@ -149,6 +150,14 @@ Course.class_eval do
     end
   end
   handle_asynchronously :update_context_module_completion_reqs
+
+  def relock_warning_check
+    # @relock_warning = session[:relock_warning]
+  end
+
+  def relock_warning?
+    @relock_warning
+  end
 
   private
   def filtered_announcements(filter)

--- a/app/decorators/models/course_decorator.rb
+++ b/app/decorators/models/course_decorator.rb
@@ -150,6 +150,12 @@ Course.class_eval do
   end
   handle_asynchronously :update_context_module_completion_reqs
 
+  def relock
+    context_modules.each do |context_module|
+      context_module.relock_progressions
+    end
+  end
+
   private
   def filtered_announcements(filter)
     active_announcements.where("discussion_topics.id IN (?)", filter.map(&:id))


### PR DESCRIPTION
[QTY-1617](https://strongmind.atlassian.net/browse/QTY-1617)

## Purpose 
When teachers change minimum threshold settings (at the course level) for assignment groups, they should have the option to relock modules for students who no longer meet the updated minimum threshold requirements. 

## Approach 
We created a template and view for our relock warning modal (RelockModulesDialog.handlebars & RelockModulesDialog.coffee) that renders after course settings are edited and after the page refreshes. The render function has a condition on it to make sure we only display the warning if threshold settings were changed.

If the teacher chooses to relock modules, it'll hit our new relock action at the course level. This action grabs all the modules for the course and relocks progressions on each one.

## Testing
We tested locally and in new-id-sandbox. We set up a scenario where assignments in a module need to be completed in sequential order. We set a minimum threshold on these assignments, completed the assignments as a test student, and graded the assignments so they are just above the minimum threshold. Then, we raised the threshold in course settings and chose to relock modules in our new warning dialog. We verified that the test student was forced to redo the assignments since they no longer met the new requirements.

## Screenshots/Video
This is the relock dialog that will display when course threshold settings are edited (after saving).
<img width="1715" alt="image" src="https://user-images.githubusercontent.com/87540376/217044814-a252feeb-c7c7-4535-a7bf-6c0cf7ff292a.png">


[QTY-1617]: https://strongmind.atlassian.net/browse/QTY-1617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ