### PR TITLE
QTY-1906

### DIFF
--- a/app/decorators/models/delayed/job.rb
+++ b/app/decorators/models/delayed/job.rb
@@ -6,11 +6,4 @@ Delayed::Job.class_eval do
     puts self.source if self.source.length > limit
     self.source = self.source[0..limit-1] if self.source.length > limit
   end
-
-  def self.alert_long_running_jobs
-    jobs = Delayed::Job.where('locked_at <= ?', 12.hours.ago)
-    if jobs.any?
-      Rails.logger.warn "[JOB QUEUE] #{jobs.count} delayed jobs running for more than 12 hours"
-    end
-  end
 end

--- a/app/decorators/models/delayed/job.rb
+++ b/app/decorators/models/delayed/job.rb
@@ -6,4 +6,11 @@ Delayed::Job.class_eval do
     puts self.source if self.source.length > limit
     self.source = self.source[0..limit-1] if self.source.length > limit
   end
+
+  def self.alert_long_running_jobs
+    jobs = Delayed::Job.where('locked_at <= ?', 12.hours.ago)
+    if jobs.any?
+      Rails.logger.warn "[JOB QUEUE] #{jobs.count} delayed jobs running for more than 12 hours"
+    end
+  end
 end

--- a/app/services/monitoring_service.rb
+++ b/app/services/monitoring_service.rb
@@ -1,0 +1,8 @@
+module MonitoringService
+  def self.alert_long_running_jobs
+    jobs = Delayed::Job.where('locked_at <= ?', 12.hours.ago)
+    if jobs.any?
+      Rails.logger.warn "[JOB QUEUE] #{jobs.count} delayed #{"job".pluralize(jobs.count)} running for more than 12 hours"
+    end
+  end
+end


### PR DESCRIPTION
[QTY-1906](https://strongmind.atlassian.net/browse/QTY-1906)

## Purpose 
In Enterprise Canvas, DelayedJobs that have been locked for longer than 12 hours are likely to have failed and have consequences ranging from courses not successfully receiving their content due to a failed migration to potentially to blocking the queue from continuing to process jobs effectively. In order to help us manage these failed jobs we need to be alerted that they've been running for a significant period of time.

## Approach 
To provide better alerting so we can be more proactive with failed jobs, we made changes to `canvas_shim`, `canvas-lms`, and in `AWS`. 

In the shim, we created a `MonitoringService` module to house the method that would start the process of creating an alert. This module should be generic enough that it will also allow us to add code for any potential future metrics which need monitoring. The service implements `#alert_long_running_jobs`. The method will simply query for `Delayed::Job` records that have been locked for 12 hours of more, and if any exist, write a warning to the Rails log. This allows us to implement log metrics and create alerts in AWS that subsequently trigger an OpsGenie alert to the team indicating that there are long running jobs. 

In the canvas-lms repo, we added a cron job to `periodic_jobs.rb` that invokes `MonitoringService.alert_long_running_jobs` on an hourly basis. 

In AWS, all Enterprise Canvas instances had a log-metric for `job-queue-log` added to them. This metric will search for occurrences of `[JOB QUEUE]` in the production logs for each customer which indicates that we created a log for long running jobs. Each log-metric then had an alert created for it which will check on an hourly basis to see if the threshold of 1 or more occurrences of the metric has been met. If 1 or more occurrences exist, an OpsGenie alert is sent to the team indicating which instance has a long running job. 

## Testing
I've since deleted the AWS alarm for newidsandbox so that we weren't continually getting alerts and new bug tickets in Jira but confirmed this works by having a few instances of failed delayed jobs on the test environment and setting the cron job in canvas-lms to run every minute so that we could verify the integration. Screenshots from the test below:

#### Failed jobs on newidsandbox:
<img width="1725" alt="image" src="https://user-images.githubusercontent.com/30609917/230229445-206f038c-e2ca-49b8-a516-28d9d55b2f68.png">

#### Cloudwatching logging as a result of the cron job/MonitoringService:
<img width="1316" alt="image" src="https://user-images.githubusercontent.com/30609917/230229911-1654e572-b7a8-4b61-9c28-fdcd4fd2421a.png">

#### OpsGenie alert created as a result:
<img width="1420" alt="image" src="https://user-images.githubusercontent.com/30609917/230230084-29cd26f5-e0c0-4c64-94ba-8e5ae65db29a.png">

## Screenshots/Video
n/a - provided in testing section
