### PR TITLE
QTY-2663

### DIFF
--- a/app/services/monitoring_service.rb
+++ b/app/services/monitoring_service.rb
@@ -2,7 +2,14 @@ module MonitoringService
   def self.alert_long_running_jobs
     jobs = Delayed::Job.where('locked_at <= ?', 12.hours.ago)
     if jobs.any?
-      Rails.logger.warn "[JOB QUEUE] #{jobs.count} delayed #{"job".pluralize(jobs.count)} running for more than 12 hours"
+      Rails.logger.warn "[JOB QUEUE] #{jobs.count} delayed #{"job".pluralize(jobs.count)} running for more than 12 hours. Job IDs: #{jobs.pluck(:id)}"
+      MonitoringService.requeue_long_running_jobs(jobs)
+    end
+  end
+
+  def self.requeue_long_running_jobs(jobs)
+    jobs.each do |job|
+      job.update!(run_at: 15.minutes.from_now, locked_by: nil, locked_at: nil, attempts: 0)
     end
   end
 end

--- a/app/services/monitoring_service.rb
+++ b/app/services/monitoring_service.rb
@@ -2,7 +2,7 @@ module MonitoringService
   def self.alert_long_running_jobs
     jobs = Delayed::Job.where('locked_at <= ?', 12.hours.ago)
     if jobs.any?
-      Rails.logger.warn "[JOB QUEUE] #{jobs.count} delayed #{"job".pluralize(jobs.count)} running for more than 12 hours. Job IDs: #{jobs.pluck(:id)}"
+      Rails.logger.warn "[JOB QUEUE] #{jobs.count} delayed #{"job".pluralize(jobs.count)} running for more than 12 hours. Original Job IDs: #{jobs.pluck(:id)}"
       MonitoringService.requeue_long_running_jobs(jobs)
     end
   end


### PR DESCRIPTION
[QTY-2663](https://strongmind.atlassian.net/browse/QTY-2663)

## Purpose 
Since the new alerts created by work on [this](https://github.com/StrongMind/canvas_shim/pull/434) PR will be repeatedly raised, even once acknowledged in OpsGenie, until the stuck jobs have been re-queued, we want to automatically handle re-queueing of long running jobs. 

## Approach 
Implement a new method `#requeue_long_running_jobs` in `MonitoringService` which takes in a collection of `Delayed::Jobs` which have been locked for greater than 12 hours. After writing to the Rails log so that AWS can create an alert for us in OpsGenie, re-queue the collection of jobs by iterating over it and setting `locked_at` and `locked_by` to `nil` (in most cases, a long running job is locked by a worker that no longer exists), `attempts` to 0, and setting `run_at` to 15 minutes in the future. 

We also updated the warning logged to AWS to include the `Original Job IDs` of the stuck jobs as an array. This is helpful for verifying that the automatically re-queued jobs were successful on retry. This can be done by querying for `Delayed::Job.where(id: [array_of_ids])` and also `Delayed::Job::Failed.where(original_job_id: [array_of_ids])`. 

## Testing
Performed the same test outlined [here](https://github.com/StrongMind/canvas_shim/pull/434)

## Screenshots/Video
#### New example log in AWS
<img width="1310" alt="image" src="https://user-images.githubusercontent.com/30609917/230681926-12d5e6b5-a150-4faa-8dc3-60e7c2a7d724.png">


[QTY-2663]: https://strongmind.atlassian.net/browse/QTY-2663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ