### PR TITLE
QTY-2708: Update to check for AADId instead of admin

### DIFF
--- a/app/decorators/models/account_authorization_config/open_id_connect_decorator.rb
+++ b/app/decorators/models/account_authorization_config/open_id_connect_decorator.rb
@@ -1,8 +1,6 @@
 AccountAuthorizationConfig::OpenIDConnect.class_eval do
-  def admin_role?(token)
-    return unless roles(token)
-    setting = SettingsService.global_settings["admin_roles"] || ""
-    setting.split(",").any? { |role| roles(token).include?(role) }
+  def aad_account?(token)
+    return aad_id(token)
   end
 
   def identity_email_address(token)
@@ -13,7 +11,7 @@ AccountAuthorizationConfig::OpenIDConnect.class_eval do
 
   private
 
-  def roles(token)
-    claims(token)["role"]
+  def aad_id(token)
+    claims(token)["AADId"]
   end
 end

--- a/spec/models/open_id_connect_spec.rb
+++ b/spec/models/open_id_connect_spec.rb
@@ -1,48 +1,20 @@
 describe AccountAuthorizationConfig::OpenIDConnect do
   subject { described_class.new }
 
-  describe "admin_role?" do
-    context "Admin role exists in SettingsService" do
-      before do
-        allow(SettingsService).to receive(:global_settings).and_return(
-          { "admin_roles" => "sgi-developers,cat,dog" }
-        )
-      end
-
+  describe "aad_account?" do
+    context "User is AAD user" do
       it "Returns truthy" do
-        expect(subject.admin_role?("12345")).to be_truthy
-      end
-  
-      context "Claims don't have role" do
-        before do
-          allow(subject).to receive(:claims).and_return({})
-        end
-
-        it "Returns falsy if claims don't have role" do
-          expect(subject.admin_role?("12345")).to be_falsy
-        end
+        expect(subject.aad_account?("12345")).to be_truthy
       end
     end
 
-    context "Admin role does not exist in SettingsService" do
+    context "User is not an AAD user" do
       before do
-        allow(SettingsService).to receive(:global_settings).and_return(
-          { "admin_roles" => "pony,cat,dog" }
-        )
+        allow(subject).to receive(:claims).and_return({})
       end
 
       it "Returns falsy" do
-        expect(subject.admin_role?("12345")).to be_falsy
-      end
-    end
-
-    context "Setting does not exist" do
-      before do
-        allow(SettingsService).to receive(:global_settings).and_return({})
-      end
-
-      it "Returns falsy" do
-        expect(subject.admin_role?("12345")).to be_falsy
+        expect(subject.aad_account?("12345")).to be_falsy
       end
     end
   end


### PR DESCRIPTION
[QTY-2708](https://strongmind.atlassian.net/browse/QTY-2708)

## Purpose 
Users in CDCR were experiencing a bug where they were having multiple accounts created on login. This change is to prevent a new user record from being created when logging into CDCR.

## Approach 
As part of the login process, the existence of a `Pseudonym` is checked for a `User`. If a Pseudonym record is not found, a new User record is created. This occurs when the `unique_id` is unable to be matched for a given user. 

We should be matching on the `integration_id` of a User, however, we were previously only doing this in cases where a User was considered an `admin` based on a stored setting. 

This change checks that a User is considered an `aad_user` (they exist in the Azure database of StrongMind users) rather than checking that they belong to one of the `roles` that previously classified a User as an `admin`. 

## Testing
- Log out of identity 
- Log in to an instance of enterprise canvas
- Ensure that a new User is not created and login is successful
- Edit unique ID of the User
- Log out of enterprise canvas
- Log back in to enterprise canvas
- Again, ensure that a new User is not created and login is successful

## Screenshots/Video
n/a 
