### PR TITLE
(S) QTY-3926: remove feature flag for expose_default_course_access_times

### DIFF
--- a/app/decorators/controllers/accounts_controller_decorator.rb
+++ b/app/decorators/controllers/accounts_controller_decorator.rb
@@ -35,7 +35,6 @@ AccountsController.class_eval do
 
     @expose_first_and_last_assignment_due_date_field = Rails.configuration.launch_darkly_client.variation("expose-first-and-last-assignment-due-date-field", @launch_darkly_user, false)
     @expose_discussion_and_project_threshold_field = Rails.configuration.launch_darkly_client.variation("expose-discussion-and-project-threshold-field", @launch_darkly_user, false)
-    @expose_default_course_access_times = Rails.configuration.launch_darkly_client.variation("expose-default-course-access-times", @launch_darkly_user, false)
 
     js_env({
       HOLIDAYS: @holidays,

--- a/app/views/accounts/settings.html.erb
+++ b/app/views/accounts/settings.html.erb
@@ -129,20 +129,21 @@
               </td>
             </tr>
             <script type="text/javascript">
-                function htmlToElement(html) {
-                    var template = document.createElement('template');
-                    template.innerHTML = html;
-                    return template.content.firstChild;
-                }
+              function htmlToElement (html) {
+                var template = document.createElement('template');
+                template.innerHTML = html;
+                return template.content.firstChild;
+              }
 
-                function addInput() {
-                    let input = '<div><input name="account[settings][domains][]" type="text" class="same-width-as-select"/></div>';
-                    let domainInput = htmlToElement(input)
-                    document.getElementById("domains-form-container").appendChild(domainInput)
-                }
+              function addInput () {
+                let input = '<div><input name="account[settings][domains][]" type="text" class="same-width-as-select"/></div>';
+                let domainInput = htmlToElement(input)
+                document.getElementById('domains-form-container')
+                  .appendChild(domainInput)
+              }
 
-                let el = document.getElementById("add-domain-input");
-                el.addEventListener('click', addInput, false);
+              let el = document.getElementById('add-domain-input');
+              el.addEventListener('click', addInput, false);
             </script>
             <% if !@account.root_account? && (@context.sis_source_id && can_do(@context.root_account, @current_user, :read_sis) || can_do(@context.root_account, @current_user, :manage_sis)) %>
               <tr>
@@ -458,63 +459,61 @@ Join the [Canvas Translation Community](%{transifex_url})
           </fieldset>
         <% end %>
 
-        <% if @expose_default_course_access_times %>
-          <fieldset>
-            <legend><%= t(:course_start_time, 'Default Course Access Times') %>
-            </legend>
-            <table>
-              <tr>
-                <td colspan=2>
-                  <p style="font-size: 0.9em;"><%= t("This setting affects when a student will be able to access a course on the first day and when access closes on the last day.") %></p>
-                </td>
-              </tr>
-              <tr>
-                <td style="width:15%" class="form-label"><%= f.blabel :course_start_time, :en => "Course Start Time" %></td>
-                <td class="formtable small-select">
-                  <%= f.fields_for :settings do |settings| %>
-                    <%= settings.number_field :course_start_time_hour,
-                                              :value => @course_start_time_hour,
-                                              :default => @course_start_time_hour,
-                                              :min => "01",
-                                              :max => "12",
-                                              :style => "width: 40px;",
-                                              :disabled => false %> :
-                    <%= settings.number_field :course_start_time_minute,
-                                              :value => @course_start_time_minute,
-                                              :default => @course_start_time_minute,
-                                              :min => "00",
-                                              :max => "59",
-                                              :style => "width: 40px;",
-                                              :disabled => false %>
-                    <%= settings.select :course_start_time_ampm, [["AM", "AM"], ["PM", "PM"]], :selected => @course_start_time_ampm, :style => "width: 20px;" %>
-                  <% end %>
-                </td>
-              </tr>
-              <tr>
-                <td style="width:15%" class="form-label"><%= f.blabel :course_end_time, :en => "Course End Time" %></td>
-                <td class="formtable small-select">
-                  <%= f.fields_for :settings do |settings| %>
-                    <%= settings.number_field :course_end_time_hour,
-                                              :value => @course_end_time_hour,
-                                              :default => @course_end_time_hour,
-                                              :min => "01",
-                                              :max => "12",
-                                              :style => "width: 40px;",
-                                              :disabled => false %> :
-                    <%= settings.number_field :course_end_time_minute,
-                                              :value => @course_end_time_minute,
-                                              :default => @course_end_time_minute,
-                                              :min => "00",
-                                              :max => "59",
-                                              :style => "width: 40px;",
-                                              :disabled => false %>
-                    <%= settings.select :course_end_time_ampm, [["AM", "AM"], ["PM", "PM"]], :selected => @course_end_time_ampm, :style => "width: 20px;" %>
-                  <% end %>
-                </td>
-              </tr>
-            </table>
-          </fieldset>
-        <% end %>
+        <fieldset>
+          <legend><%= t(:course_start_time, 'Default Course Access Times') %>
+          </legend>
+          <table>
+            <tr>
+              <td colspan=2>
+                <p style="font-size: 0.9em;"><%= t("This setting affects when a student will be able to access a course on the first day and when access closes on the last day.") %></p>
+              </td>
+            </tr>
+            <tr>
+              <td style="width:15%" class="form-label"><%= f.blabel :course_start_time, :en => "Course Start Time" %></td>
+              <td class="formtable small-select">
+                <%= f.fields_for :settings do |settings| %>
+                  <%= settings.number_field :course_start_time_hour,
+                                            :value => @course_start_time_hour,
+                                            :default => @course_start_time_hour,
+                                            :min => "01",
+                                            :max => "12",
+                                            :style => "width: 40px;",
+                                            :disabled => false %> :
+                  <%= settings.number_field :course_start_time_minute,
+                                            :value => @course_start_time_minute,
+                                            :default => @course_start_time_minute,
+                                            :min => "00",
+                                            :max => "59",
+                                            :style => "width: 40px;",
+                                            :disabled => false %>
+                  <%= settings.select :course_start_time_ampm, [["AM", "AM"], ["PM", "PM"]], :selected => @course_start_time_ampm, :style => "width: 20px;" %>
+                <% end %>
+              </td>
+            </tr>
+            <tr>
+              <td style="width:15%" class="form-label"><%= f.blabel :course_end_time, :en => "Course End Time" %></td>
+              <td class="formtable small-select">
+                <%= f.fields_for :settings do |settings| %>
+                  <%= settings.number_field :course_end_time_hour,
+                                            :value => @course_end_time_hour,
+                                            :default => @course_end_time_hour,
+                                            :min => "01",
+                                            :max => "12",
+                                            :style => "width: 40px;",
+                                            :disabled => false %> :
+                  <%= settings.number_field :course_end_time_minute,
+                                            :value => @course_end_time_minute,
+                                            :default => @course_end_time_minute,
+                                            :min => "00",
+                                            :max => "59",
+                                            :style => "width: 40px;",
+                                            :disabled => false %>
+                  <%= settings.select :course_end_time_ampm, [["AM", "AM"], ["PM", "PM"]], :selected => @course_end_time_ampm, :style => "width: 20px;" %>
+                <% end %>
+              </td>
+            </tr>
+          </table>
+        </fieldset>
 
         <%= render partial: 'additional_settings', locals: { f: f } %>
 


### PR DESCRIPTION
[QTY-3926](https://strongmind.atlassian.net/browse/QTY-3926)

## Purpose 
This pr removes the feature flag for exposing default course access times to partners. this feature is being released and no longer needs to be gated behind a flag

## Approach 
remove the flag and the one reference to the flag on the front end.

## Testing
n/a

## Screenshots/Video
n/a

[QTY-3926]: https://strongmind.atlassian.net/browse/QTY-3926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ