### PR TITLE
(B) QTY-3927: remove reference to feature flag

### DIFF
--- a/app/decorators/controllers/accounts_controller_decorator.rb
+++ b/app/decorators/controllers/accounts_controller_decorator.rb
@@ -33,7 +33,6 @@ AccountsController.class_eval do
 
     @module_editing_disabled = RequirementsService.disable_module_editing_on?
 
-    @expose_first_and_last_assignment_due_date_field = Rails.configuration.launch_darkly_client.variation("expose-first-and-last-assignment-due-date-field", @launch_darkly_user, false)
     @expose_discussion_and_project_threshold_field = Rails.configuration.launch_darkly_client.variation("expose-discussion-and-project-threshold-field", @launch_darkly_user, false)
 
     js_env({

--- a/app/views/accounts/settings.html.erb
+++ b/app/views/accounts/settings.html.erb
@@ -425,39 +425,37 @@ Join the [Canvas Translation Community](%{transifex_url})
         <% end %>
 
 
-        <% if @expose_first_and_last_assignment_due_date_field %>
-          <fieldset>
-            <legend><%= t(:distribute_due_dates_settings, 'Distribute Due Dates') %></legend>
-            <table class="formtable">
-              <%= f.fields_for :settings do |settings| %>
-                <tr>
-                  <td><%= settings.blabel :first_assignment_due, :en => "First Assignment Due" %></td>
-                  <td>
-                    <%= settings.number_field :first_assignment_due,
-                                              :value => @first_assignment_due || 1,
-                                              :min => "0",
-                                              :max => "31",
-                                              :style => "width: 40px;",
-                                              :disabled => false %>
-                    School day(s) after first day
-                  </td>
-                </tr>
-                <tr>
-                  <td><%= settings.blabel :last_assignment_due, :en => "Last Assignment Due" %></td>
-                  <td>
-                    <%= settings.number_field :last_assignment_due,
-                                              :value => @last_assignment_due || 2,
-                                              :min => "0",
-                                              :max => "31",
-                                              :style => "width: 40px;",
-                                              :disabled => false %>
-                    School day(s) before last day
-                  </td>
-                </tr>
-              <% end %>
-            </table>
-          </fieldset>
-        <% end %>
+        <fieldset>
+          <legend><%= t(:distribute_due_dates_settings, 'Distribute Due Dates') %></legend>
+          <table class="formtable">
+            <%= f.fields_for :settings do |settings| %>
+              <tr>
+                <td><%= settings.blabel :first_assignment_due, :en => "First Assignment Due" %></td>
+                <td>
+                  <%= settings.number_field :first_assignment_due,
+                                            :value => @first_assignment_due || 1,
+                                            :min => "0",
+                                            :max => "31",
+                                            :style => "width: 40px;",
+                                            :disabled => false %>
+                  School day(s) after first day
+                </td>
+              </tr>
+              <tr>
+                <td><%= settings.blabel :last_assignment_due, :en => "Last Assignment Due" %></td>
+                <td>
+                  <%= settings.number_field :last_assignment_due,
+                                            :value => @last_assignment_due || 2,
+                                            :min => "0",
+                                            :max => "31",
+                                            :style => "width: 40px;",
+                                            :disabled => false %>
+                  School day(s) before last day
+                </td>
+              </tr>
+            <% end %>
+          </table>
+        </fieldset>
 
         <fieldset>
           <legend><%= t(:course_start_time, 'Default Course Access Times') %>


### PR DESCRIPTION
expose-first-and-last-assignment-due-date-field: this feature has been fully released and no longer required the flag

[QTY-3927](https://strongmind.atlassian.net/browse/QTY-3927)

## Purpose 
expose-first-and-last-assignment-due-date-field: this feature has been fully released and no longer required the flag

## Approach 
remove references to flag

## Testing
will deploy & test on new-id-sandbox

## Screenshots/Video
n/a

[QTY-3927]: https://strongmind.atlassian.net/browse/QTY-3927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ