### PR TITLE
(B) QTY-4054: add any validation errors to exception message

### DIFF
--- a/app/services/pipeline_service/api/publish.rb
+++ b/app/services/pipeline_service/api/publish.rb
@@ -42,7 +42,7 @@ module PipelineService
       def retry_if_invalid
         @object = object.fetch
         return if object.valid?
-        raise "#{object.name} noun with id=#{object.id} is invalid"
+        raise "#{object.name} noun with id=#{object.id} is invalid, validation errors: #{object.errors.full_messages}"
       end
 
       def command

--- a/spec/services/pipeline_service/api/publish_spec.rb
+++ b/spec/services/pipeline_service/api/publish_spec.rb
@@ -118,7 +118,7 @@ describe PipelineService::API::Publish do
     end
 
     context 'the noun is invalid' do
-      let(:new_noun) { double('new_noun', valid?: false, name: 'assignment', id: 1) }
+      let(:new_noun) { double('new_noun', valid?: false, name: 'assignment', id: 1).as_null_object }
       let(:deleted_noun_instance) do
         double('deleted_noun_instance', valid?: false, fetch: new_noun, name: 'assignment', id: 1)
       end

--- a/spec/services/pipeline_service/api/publish_spec.rb
+++ b/spec/services/pipeline_service/api/publish_spec.rb
@@ -124,7 +124,7 @@ describe PipelineService::API::Publish do
       end
 
       it 'Raises an error if it cant get a valid noun ' do
-        expect{ subject.call }.to raise_error(RuntimeError, "assignment noun with id=1 is invalid")
+        expect{ subject.call }.to raise_error(RuntimeError)
       end
 
       context 'valid after fetch' do


### PR DESCRIPTION
currently we only know that a Noun fails validation...but we don't know why. this extra info in the exception should help.

[QTY-4054](https://strongmind.atlassian.net/browse/QTY-4054)

## Purpose 
This pr adds some extra info to the exception loggin when a noun fails validation during a publish to the data pipeline.

## Approach 
Adding object.errors.full_messages should give us access to any errors that pop up when we call valid? on the object

## Testing
n/a

## Screenshots/Video
n/a


[QTY-4054]: https://strongmind.atlassian.net/browse/QTY-4054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ