### PR TITLE
BEL-1475 Log number of remaining jobs and idle workers in queue for autoscaling

### DIFF
--- a/app/decorators/lib/delayed/work_queue/parent_process/server.rb
+++ b/app/decorators/lib/delayed/work_queue/parent_process/server.rb
@@ -1,0 +1,13 @@
+Delayed::WorkQueue::ParentProcess::Server.class_eval do
+
+  alias_method :original_check_for_work, :check_for_work
+
+  def check_for_work
+    # set logger into debug mode to trigger logging number
+    # of jobs in queue and idle workers
+    original_log_level = Rails.logger.level
+    Rails.logger.level = Logger::DEBUG
+    original_check_for_work
+    Rails.logger.level = original_log_level
+  end
+end


### PR DESCRIPTION

[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-1475)

## Purpose 
So that we can autoscale the number of workers, we need to be able to see the number of idle workers and remaining jobs.

## Approach 
Because the original check_for_work method does this when DEBUG logging when checking for work, and there are no other debug logs in the method, wrap the original method and set the log level to debug temporarily.

See https://github.com/instructure/inst-jobs/blame/e3a9feecb43fd9d7dac02623a6de806f97b576ab/lib/delayed/work_queue/parent_process/server.rb#L99

## Testing
Tested in new-id-sandbox