### PR TITLE
QTY-4491 add timezone setting, include it on start/end time setting, and remove DateTime.parse

### DIFF
--- a/app/decorators/controllers/accounts_controller_decorator.rb
+++ b/app/decorators/controllers/accounts_controller_decorator.rb
@@ -15,8 +15,9 @@ AccountsController.class_eval do
     get_allowed_filetypes
     get_first_assignment_due
     get_last_assignment_due
-    course_start_time = DateTime.parse(get_course_start_time)
-    course_end_time = DateTime.parse(get_course_end_time)
+    timezone = SettingsService.get_settings(object: 'school', id: 1)['timezone']
+    course_start_time = "#{get_course_start_time} #{timezone}"
+    course_end_time = "#{get_course_end_time} #{timezone}"
     @course_start_time_hour = course_start_time.strftime("%I")
     @course_start_time_minute = course_start_time.strftime("%M")
     @course_start_time_ampm = course_start_time.strftime("%p")

--- a/app/decorators/controllers/accounts_controller_decorator.rb
+++ b/app/decorators/controllers/accounts_controller_decorator.rb
@@ -179,7 +179,7 @@ AccountsController.class_eval do
     start_time_hour = "#{params[:account][:settings]['course_start_time_hour']}"
     start_time_minute = "#{params[:account][:settings]['course_start_time_minute']}"
     ampm = "#{params[:account][:settings]['course_start_time_ampm']}"
-    start_time = "#{start_time_hour}:#{start_time_minute} #{ampm}"
+    start_time = "#{start_time_hour}:#{start_time_minute} #{ampm} #{SettingsService.get_settings(object: 'school', id: 1)["timezone"]}"
 
     SettingsService.update_settings(
       object: 'school',
@@ -193,7 +193,7 @@ AccountsController.class_eval do
     end_time_hour = "#{params[:account][:settings]['course_end_time_hour']}"
     end_time_minute = "#{params[:account][:settings]['course_end_time_minute']}"
     ampm = "#{params[:account][:settings]['course_end_time_ampm']}"
-    end_time = "#{end_time_hour}:#{end_time_minute} #{ampm}"
+    end_time = "#{end_time_hour}:#{end_time_minute} #{ampm} #{SettingsService.get_settings(object: 'school', id: 1)["timezone"]}"
 
     SettingsService.update_settings(
       object: 'school',

--- a/app/decorators/controllers/accounts_controller_decorator.rb
+++ b/app/decorators/controllers/accounts_controller_decorator.rb
@@ -15,9 +15,9 @@ AccountsController.class_eval do
     get_allowed_filetypes
     get_first_assignment_due
     get_last_assignment_due
-    timezone = SettingsService.get_settings(object: 'school', id: 1)['timezone']
-    course_start_time = "#{get_course_start_time} #{timezone}"
-    course_end_time = "#{get_course_end_time} #{timezone}"
+    course_start_time = DateTime.parse(get_course_start_time)
+    course_end_time = DateTime.parse(get_course_end_time)
+
     @course_start_time_hour = course_start_time.strftime("%I")
     @course_start_time_minute = course_start_time.strftime("%M")
     @course_start_time_ampm = course_start_time.strftime("%p")
@@ -157,6 +157,10 @@ AccountsController.class_eval do
     SettingsService.get_settings(object: 'school', id: 1)['course_end_time'] || "11:59 PM"
   end
 
+  def get_timezone
+    SettingsService.get_settings(object: 'school', id: 1)['timezone'] || "UTC"
+  end
+
   def set_first_assignment_due
     SettingsService.update_settings(
       object: 'school',
@@ -179,7 +183,7 @@ AccountsController.class_eval do
     start_time_hour = "#{params[:account][:settings]['course_start_time_hour']}"
     start_time_minute = "#{params[:account][:settings]['course_start_time_minute']}"
     ampm = "#{params[:account][:settings]['course_start_time_ampm']}"
-    start_time = "#{start_time_hour}:#{start_time_minute} #{ampm} #{SettingsService.get_settings(object: 'school', id: 1)["timezone"]}"
+    start_time = "#{start_time_hour}:#{start_time_minute} #{ampm} #{get_timezone}"
 
     SettingsService.update_settings(
       object: 'school',
@@ -193,7 +197,7 @@ AccountsController.class_eval do
     end_time_hour = "#{params[:account][:settings]['course_end_time_hour']}"
     end_time_minute = "#{params[:account][:settings]['course_end_time_minute']}"
     ampm = "#{params[:account][:settings]['course_end_time_ampm']}"
-    end_time = "#{end_time_hour}:#{end_time_minute} #{ampm} #{SettingsService.get_settings(object: 'school', id: 1)["timezone"]}"
+    end_time = "#{end_time_hour}:#{end_time_minute} #{ampm} #{get_timezone}"
 
     SettingsService.update_settings(
       object: 'school',

--- a/app/decorators/models/course_decorator.rb
+++ b/app/decorators/models/course_decorator.rb
@@ -107,11 +107,7 @@ Course.class_eval do
         setting_name = method == "start_at" ? "course_start_time" : "course_end_time"
         course_time = SettingsService.get_settings(object: 'school', id: 1)[setting_name]
         return if course_time.nil?
-        course_date_time = DateTime.parse(course_time)
-        course_time_hour = course_date_time.hour.to_i
-        course_time_minute = course_date_time.minute.to_i
-
-        self.send("#{method}=", DateTime.new(self.send(method).year, self.send(method).month, self.send(method).day, course_time_hour, course_time_minute, 0, Time.zone.now.formatted_offset))
+        self.send("#{method}=", course_time)
       end
     end
   end


### PR DESCRIPTION
[QTY-4491](https://strongmind.atlassian.net/browse/QTY-4491)

## Purpose 
Bug: courses created from powerschool to canvas were coming in with incorrect course start/end times even when the account setting was set.

## Approach 
Add a timezone setting since system setting is always UTC. Append this timezone to the existing start time and end time settings. Remove DateTime.parse because this creates an offset on the date (causes multiple offsets to happen). If we allow the course to create itself using the start/end time directly, it automatically adjusts itself to the system timezone

In other words, setting start_at of a course to the start time in the setting:

`course.start_at = "12:00 AM MST"`

Automatically translates to this in the DB:

`start_at: "2023-09-14 07:00:00"`

## Testing
Test locally in the rails console
Deploy to newidsandbox, create a new course via postman (Steakholders workspace --> Canvas API (Enterprise) collection --> Courses --> Create a new course)
Verify that the course is created with correct start/end times (according to the account settings)

## Screenshots/Video
<img width="737" alt="image" src="https://github.com/StrongMind/canvas_shim/assets/87540376/de98cb2f-9829-47b6-814b-45930ac384a4">

<img width="421" alt="image" src="https://github.com/StrongMind/canvas_shim/assets/87540376/c1c54efc-d2f6-477d-b280-624e70f86a3d">

<img width="1229" alt="image" src="https://github.com/StrongMind/canvas_shim/assets/87540376/625ab212-6e2d-4a7f-b45d-3b7d3a28cf6e">

[QTY-4491]: https://strongmind.atlassian.net/browse/QTY-4491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ