### PR TITLE
QTY-4252 add safeguarding for when module_item is nil, ensure element properties are formatted correctly

### DIFF
--- a/app/views/context_modules/_module_item_next.html.erb
+++ b/app/views/context_modules/_module_item_next.html.erb
@@ -60,12 +60,12 @@
       tabindex="-1"
       class="for-nvda"
       content_type="<%= module_item ? module_item.content_type : '' %>"
-      assignment_id=
+      assignment_id="
       <% if module_item.try(:content_type) == "DiscussionTopic" %>
         <%= module_item.content.try(:assignment_id) %>
       <% elsif module_item %>
         <%= module_item.content_id %>
-      <% end %>
+      <% end %>"
 
       href="<%= context_url(@context, :context_url) %>/modules/items/<%= module_item ? module_item.id : "{{ id }}" %>">
       <%= module_item && module_item.title %>
@@ -106,12 +106,12 @@
               title="<%= module_item && module_item.title %>"
               class="title external_url_link"
                 content_type="<%= module_item ? module_item.content_type : '' %>"
-                assignment_id=
+                assignment_id="
                 <% if module_item.try(:content_type) == "DiscussionTopic" %>
                   <%= module_item.content.try(:assignment_id) %>
                 <% elsif module_item %>
                   <%= module_item.content_id %>
-                <% end %> 
+                <% end %>"
               target="_blank"
               href="<%= module_item.url %>"
               data-item-href="<%= context_url(@context, :context_url) %>/modules/items/<%= module_item.id %>"
@@ -125,12 +125,12 @@
               title="<%= module_item && module_item.title %>"
               class="ig-title title"
                 content_type="<%= module_item ? module_item.content_type : '' %>"
-                assignment_id=
+                assignment_id="
                 <% if module_item.try(:content_type) == "DiscussionTopic" %>
                   <%= module_item.content.try(:assignment_id) %>
                 <% elsif module_item %>
                   <%= module_item.content_id %>
-                <% end %>
+                <% end %>"
 
               href="<%= context_url(@context, :context_url) %>/modules/items/<%= module_item ? module_item.id : "{{ id }}" %>"
               <% if item_data[:mastery_paths] && item_data[:mastery_paths][:locked] %>


### PR DESCRIPTION
[QTY-4252](https://strongmind.atlassian.net/browse/QTY-4252)

## Purpose 
This is part of a fix for a bug that happens when a new module item is created and then the user tries to go to the item (before this fix, the user gets a "page not found" error).

This particular change is needed to fix element properties and ensure that module item URLs are assigned properly.

## Approach 
The `assignment_id` property is set to a value that relies on some conditional logic on `module_item`. For new items, `module_item` comes through as nil and therefore the property following `assignment_id` becomes the value of `assignment_id`.

i.e.

This code would have `some_conditional_logic` which would return nil:
```
assignment_id = <%= some_conditional_logic %>
href = "some_url"
```

Which would generate the element like this:
```
assignment_id = "href = "some_url""
```

Adding quotes around the conditional logic keeps the next property from being swallowed by the `assignment_id` property

## Testing
Ensure that in browser dev tools, the two properties on the module item elements are separated.
Tested locally and on new-id-sandbox.

## Screenshots/Video
Before our fix (note that assignment_id is swallowing the href property)
<img width="549" alt="image" src="https://github.com/StrongMind/canvas_shim/assets/87540376/7280d23d-c428-4bd4-8ca6-d1e3edab40bc">

After our fix (note that assigment_id and href are separated):
<img width="532" alt="image" src="https://github.com/StrongMind/canvas_shim/assets/87540376/80bca3b1-f790-4b74-98f8-bfd4ecfa1896">


[QTY-4252]: https://strongmind.atlassian.net/browse/QTY-4252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ