### PR TITLE
(B) QTY-4975: refactor set_course_start_end_time_from_school

### DIFF
--- a/app/decorators/models/course_decorator.rb
+++ b/app/decorators/models/course_decorator.rb
@@ -6,7 +6,7 @@ Course.class_eval do
       where("enrollments.workflow_state NOT IN ('rejected', 'deleted', 'inactive') AND enrollments.type = 'StudentEnrollment'").preload(:user)
     }, class_name: 'Enrollment'
 
-  before_create :set_course_start_end_time_from_school if Rails.env.production?
+  before_create :set_course_start_end_time_from_school
 
   after_commit -> { PipelineService.publish_as_v2(self) }
   after_create -> { RequirementsService.set_school_thresholds_on_course(course: self) }
@@ -110,7 +110,7 @@ Course.class_eval do
   def course_start_time_from_school
     return nil if start_at.nil?
     course_time = SettingsService.get_settings(object: 'school', id: 1)['course_start_time']
-    return nil if course_time.nil?
+    return start_at if course_time.nil?
     course_date_time = DateTime.parse(course_time)
     course_time_hour = course_date_time.hour.to_i
     course_time_minute = course_date_time.minute.to_i
@@ -120,7 +120,7 @@ Course.class_eval do
   def course_end_time_from_school
     return nil if conclude_at.nil?
     course_time = SettingsService.get_settings(object: 'school', id: 1)['course_end_time']
-    return nil if course_time.nil?
+    return conclude_at if course_time.nil?
     course_date_time = DateTime.parse(course_time)
     course_time_hour = course_date_time.hour.to_i
     course_time_minute = course_date_time.minute.to_i

--- a/app/decorators/models/course_decorator.rb
+++ b/app/decorators/models/course_decorator.rb
@@ -6,7 +6,7 @@ Course.class_eval do
       where("enrollments.workflow_state NOT IN ('rejected', 'deleted', 'inactive') AND enrollments.type = 'StudentEnrollment'").preload(:user)
     }, class_name: 'Enrollment'
 
-  before_create :set_course_start_end_time_from_school
+  before_create :set_course_start_end_time_from_school if Rails.env.production?
 
   after_commit -> { PipelineService.publish_as_v2(self) }
   after_create -> { RequirementsService.set_school_thresholds_on_course(course: self) }

--- a/app/decorators/models/course_decorator.rb
+++ b/app/decorators/models/course_decorator.rb
@@ -102,14 +102,29 @@ Course.class_eval do
   end
 
   def set_course_start_end_time_from_school
-    ["start_at", "conclude_at"].each do |method|
-      unless self.send(method).nil?
-        setting_name = method == "start_at" ? "course_start_time" : "course_end_time"
-        course_time = SettingsService.get_settings(object: 'school', id: 1)[setting_name]
-        return if course_time.nil?
-        self.send("#{method}=", course_time)
-      end
-    end
+    return if start_at.nil? && conclude_at.nil?
+    self.start_at = course_start_time_from_school
+    self.conclude_at = course_end_time_from_school
+  end
+
+  def course_start_time_from_school
+    return nil if start_at.nil?
+    course_time = SettingsService.get_settings(object: 'school', id: 1)['course_start_time']
+    return nil if course_time.nil?
+    course_date_time = DateTime.parse(course_time)
+    course_time_hour = course_date_time.hour.to_i
+    course_time_minute = course_date_time.minute.to_i
+    return DateTime.new(self.start_at.year, self.start_at.month, self.start_at.day, course_time_hour, course_time_minute, 0, Time.zone.now.formatted_offset)
+  end
+
+  def course_end_time_from_school
+    return nil if conclude_at.nil?
+    course_time = SettingsService.get_settings(object: 'school', id: 1)['course_end_time']
+    return nil if course_time.nil?
+    course_date_time = DateTime.parse(course_time)
+    course_time_hour = course_date_time.hour.to_i
+    course_time_minute = course_date_time.minute.to_i
+    return DateTime.new(self.conclude_at.year, self.conclude_at.month, self.conclude_at.day, course_time_hour, course_time_minute, 0, Time.zone.now.formatted_offset)
   end
 
   def online_user_count


### PR DESCRIPTION
the current implementation was setting start/end dates incorrectly

[QTY-4975](https://strongmind.atlassian.net/browse/QTY-4975)

## Purpose 
this pr re-implements the set_course_start_end_time_from_school, we refactored this method to be more verbose and not use the send method.

## Approach 
undo the meta programming implementation into more verbose logic

## Testing
we were able to replicate this in a rails console, once we refactored we monkey patched in the console to verify things were working correctly

## Screenshots/Video
n/a

[QTY-4975]: https://strongmind.atlassian.net/browse/QTY-4975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ