### PR TITLE
(B) QTY-5525: zero_out_assignment grades no longer pushes student enr…

### DIFF
--- a/app/services/grades_service/commands/zero_out_assignment_grades.rb
+++ b/app/services/grades_service/commands/zero_out_assignment_grades.rb
@@ -8,7 +8,6 @@ module GradesService
         @student = @submission.user
         @course = @assignment.context
         @grader = GradesService::Account.account_admin
-        @enrollment = StudentEnrollment.find_by(user: @student, course: @course, workflow_state: 'active')
       end
 
       def call!(options={})
@@ -29,10 +28,6 @@ module GradesService
         end
 
         @assignment.grade_student(@student, score: 0, grader: @grader)
-        if @enrollment
-          @enrollment.publish_as_v2
-        end
-
       end
 
       private


### PR DESCRIPTION
…ollment message

this funtionality was moved up to the canvas-lms repo to help with timing issues

[QTY-5525](https://strongmind.atlassian.net/browse/QTY-5525)

## Purpose 
This pr prevents prevents the GradeService from publishing StudentEnrollment nouns. This functionality was moved into canvas-lms

## Approach 
n/a

## Testing
This PR combined with changes in canvas-lms is deployed to new-id-sandbox, i've modified zero grader to run every 5 mins. I can see StudentEnrollment nouns firing with the correct grades now

## Screenshots/Video
<img width="1838" alt="image" src="https://github.com/StrongMind/canvas_shim/assets/88393833/e3919fa4-bc51-40fc-b3af-3fc29f62477f">
<img width="721" alt="image" src="https://github.com/StrongMind/canvas_shim/assets/88393833/ca6ac106-5fe5-441f-af0c-c68a17704272">


[QTY-5525]: https://strongmind.atlassian.net/browse/QTY-5525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ