### PR TITLE
QTY-6247: explicitly call recompute_final_score when autograder grades an assignment

### DIFF
--- a/app/services/grades_service/commands/zero_out_assignment_grades.rb
+++ b/app/services/grades_service/commands/zero_out_assignment_grades.rb
@@ -28,6 +28,12 @@ module GradesService
         end
 
         @assignment.grade_student(@student, score: 0, grader: @grader)
+
+        if @submission.context.is_a?(Course)
+          @submission.context.student_enrollments.where(user: @submission.user).each do |student_enrollment|
+            Enrollment.recompute_final_score(student_enrollment.user_id, student_enrollment.course_id)
+          end
+        end
       end
 
       private


### PR DESCRIPTION
[QTY-6247](https://strongmind.atlassian.net/browse/QTY-6247)

## Purpose 
explicitly call recompute_final_score on enrollment when zero grader grades an assignment

## Approach 
once the assignment is graded by zero grade, recompute_final_score will be called which should recompute the current scores and publish to the data pipeline

## Testing
rspec. reset patricia morans grades for [chemistry](https://new-id-sandbox.strongmind.com/courses/1821), rerun autograder and see a student enrollment noun for each assignment that got graded

## Screenshots/Video
86 assignments autograded, 86 nouns published
![image](https://github.com/StrongMind/canvas_shim/assets/88393833/4e5f4949-f299-473e-aed9-dafea126269c)

![image](https://github.com/StrongMind/canvas_shim/assets/88393833/76673d91-ed3d-4f50-aaa1-7a667f08309e)


[QTY-6247]: https://strongmind.atlassian.net/browse/QTY-6247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ