### PR TITLE
QTY-6879 Remove redundant logging

### DIFF
--- a/app/services/pipeline_service/logger.rb
+++ b/app/services/pipeline_service/logger.rb
@@ -26,10 +26,7 @@ module PipelineService
     end
 
     def post
-      http_client.post(
-        'https://3wupzgqsoh.execute-api.us-west-2.amazonaws.com/prod',
-        body: message.to_json
-      )
+      # empty body temporarily to get us through an outage, in case there are multiple places calling this.
     end
   end
 end


### PR DESCRIPTION

[Link to Jira ticket](https://strongmind.atlassian.net/browse/TEAM-NUMBER)

## Purpose 
An outage happened because an old echo service was removed, which was being used as a redundant logger for the data pipeline.

## Approach 
Remove the body of the class that was posting. We'll need to clear it out properly afterwards.

## Testing
O'reilly.
