### PR TITLE
(B) QTY-5712: log validation issues in valid? action, the object does…

### DIFF
--- a/app/services/pipeline_service/api/publish.rb
+++ b/app/services/pipeline_service/api/publish.rb
@@ -42,7 +42,7 @@ module PipelineService
       def retry_if_invalid
         @object = object.fetch
         return if object.valid?
-        raise "#{object.name} noun with id=#{object.id} is invalid, validation errors: #{object.errors.full_messages}"
+        raise "#{object.name} noun with id=#{object.id} is invalid"
       end
 
       def command

--- a/app/services/pipeline_service/models/noun.rb
+++ b/app/services/pipeline_service/models/noun.rb
@@ -54,6 +54,9 @@ module PipelineService
 
       def valid?
         return true if additional_identifiers.nil?
+        if additional_identifiers.values.any?(&:nil?)
+          Rails.logger.info "additional_identifiers contains nil values: #{additional_identifiers}"
+        end
         !additional_identifiers.values.any?(&:nil?)
       end
 


### PR DESCRIPTION
… not have

an attribute for errors

[Link to Jira ticket](https://strongmind.atlassian.net/browse/QTY-5712)

## Purpose 
in response to a sentry exception, when the noun fails to publish....we're re-raising a new exception when trying to log out any errors on the model with `object.errors.full_messages`. 

## Approach 
update `def valid?` to log when any required additional parameters are nil

## Testing
n/a

## Screenshots/Video
n/a