### PR TITLE
(B) QTY-7013 && QTY-7015: Address canvas vulnerabilities by adding authorization guard clauses

### DIFF
--- a/app/decorators/controllers/discussion_topics_controller_decorator.rb
+++ b/app/decorators/controllers/discussion_topics_controller_decorator.rb
@@ -11,6 +11,8 @@ DiscussionTopicsController.class_eval do
   alias_method :index, :strongmind_index
 
   def strongmind_update
+    @topic = @context.all_discussion_topics.active.find(params[:topic_id]) if params[:topic_id].present?
+
     return unless authorized_action(@topic, @current_user, :update)
 
     get_discussion_assignment

--- a/app/decorators/controllers/discussion_topics_controller_decorator.rb
+++ b/app/decorators/controllers/discussion_topics_controller_decorator.rb
@@ -11,6 +11,8 @@ DiscussionTopicsController.class_eval do
   alias_method :index, :strongmind_index
 
   def strongmind_update
+    return unless authorized_action(@topic, @current_user, :update)
+
     get_discussion_assignment
     ExcusedService.bulk_excuse(assignment: @assignment, exclusions: params['excluded_students'])
     instructure_update

--- a/app/decorators/controllers/users_controller_decorator.rb
+++ b/app/decorators/controllers/users_controller_decorator.rb
@@ -1,7 +1,7 @@
 UsersController.class_eval do
   def special_programs
 
-    return unless @context.grants_right?(@current_user, session, :manage_sis)
+    return unless @context.grants_right?(@current_user, session, :read_sis)
 
     accommodations = Rails.cache.read("accommodations_#{params[:id]}")
     unless accommodations

--- a/app/decorators/controllers/users_controller_decorator.rb
+++ b/app/decorators/controllers/users_controller_decorator.rb
@@ -1,5 +1,8 @@
 UsersController.class_eval do
   def special_programs
+
+    return unless @context.grants_right?(@current_user, session, :manage_sis)
+
     accommodations = Rails.cache.read("accommodations_#{params[:id]}")
     unless accommodations
       user = User.find(params[:id])
@@ -10,6 +13,9 @@ UsersController.class_eval do
   end
 
   def observer_enrollments
+
+    return unless observer_dashboard_enabled?
+
     user = User.find(params[:id])
     return render_unauthorized_action unless user
     contexts = user.observer_enrollments.map(&:course)


### PR DESCRIPTION
[QTY-7013](https://strongmind.atlassian.net/browse/QTY-7013)
[QTY-7015](https://strongmind.atlassian.net/browse/QTY-7015)

## Purpose 
Strongmind added code is not checking for user permissions before making data changes, this PR addresses that

## Approach 
Guard clauses to exit endpoints before doing data changes

## Testing
Tested on canvas VM
Special programs needs to be tested on new_id_sandbox



[QTY-7013]: https://strongmind.atlassian.net/browse/QTY-7013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[QTY-7015]: https://strongmind.atlassian.net/browse/QTY-7015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ