### PR TITLE
Fix time zone dates

### DIFF
--- a/app/decorators/models/course_decorator.rb
+++ b/app/decorators/models/course_decorator.rb
@@ -118,18 +118,16 @@ Course.class_eval do
   def coalesce_date_time(date:, time:)
     utc_time = Time.zone.parse(time)
 
-    # Rails will always try to convert this to UTC on save and subtract 7.
-    utc_offset = 7
-
-    DateTime.new(
+    dt = DateTime.new(
       date.year,
       date.month,
       date.day,
       utc_time.hour,
       utc_time.min,
-      utc_time.sec,
-      utc_offset
+      utc_time.sec
     )
+
+    time_zone.present ? dt.in_time_zone(time_zone) : dt
   end
 
   def course_end_time_from_school

--- a/app/decorators/models/course_decorator.rb
+++ b/app/decorators/models/course_decorator.rb
@@ -117,9 +117,9 @@ Course.class_eval do
   end
 
   def coalesce_date_time(date:, time:)
-    utc_time = Time.zone.parse(time)
+    utc_time = Time.zone.parse(time).utc
 
-    dt = DateTime.new(
+    DateTime.new(
       date.year,
       date.month,
       date.day,
@@ -127,8 +127,6 @@ Course.class_eval do
       utc_time.min,
       utc_time.sec
     )
-
-    time_zone.present? ? dt.in_time_zone(time_zone.split(' ').last) : dt.utc
   end
 
   def course_end_time_from_school

--- a/app/decorators/models/course_decorator.rb
+++ b/app/decorators/models/course_decorator.rb
@@ -103,6 +103,7 @@ Course.class_eval do
 
   def set_course_start_end_time_from_school
     return if start_at.nil? && conclude_at.nil?
+
     self.start_at = course_start_time_from_school
     self.conclude_at = course_end_time_from_school
   end
@@ -127,7 +128,7 @@ Course.class_eval do
       utc_time.sec
     )
 
-    time_zone.present ? dt.in_time_zone(time_zone) : dt
+    time_zone.present? ? dt.in_time_zone(time_zone.split(' ').last) : dt.utc
   end
 
   def course_end_time_from_school

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -180,7 +180,14 @@ describe Course do
         let(:time_zone) { ActiveSupport::TimeZone["America/Phoenix"] }
 
         date_param = DateTime.new(2023, 5, 18, 0, 0, 0).utc
-        let(:course) { Course.create(start_at: date_param, time_zone: time_zone) }
+        let(:course) { Course.create(start_at: date_param) }
+
+        # canvas-lms returns an ActiveSupport::TimeZone object for the time_zone
+        before do
+          def course.time_zone
+            time_zone
+          end
+        end
 
         it "matches start time in account settings" do
           expected_start_time = "07:05 AM UTC"

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -166,10 +166,28 @@ describe Course do
       let(:course) { Course.create(start_at: date_param) }
 
       it "matches start time in account settings" do
-        expected_start_time = "07:05 AM"
-        actual_start_time = course.start_at.strftime("%H:%M %p")
+        expected_start_time = "07:05 AM UTC"
+        actual_start_time = course.start_at.strftime("%H:%M %p %Z")
 
         expect(actual_start_time).to eq(expected_start_time)
+      end
+
+      context 'with a time_zone' do
+        before do
+          allow(SettingsService).to receive(:get_settings).and_return('course_start_time' => "12:05 AM MST")
+        end
+
+        let(:time_zone) { ActiveSupport::TimeZone["America/Phoenix"] }
+
+        date_param = DateTime.new(2023, 5, 18, 0, 0, 0).utc
+        let(:course) { Course.create(start_at: date_param, time_zone: time_zone) }
+
+        it "matches start time in account settings" do
+          expected_start_time = "07:05 AM UTC"
+          actual_start_time = course.start_at.strftime("%H:%M %p %Z")
+
+          expect(actual_start_time).to eq(expected_start_time)
+        end
       end
     end
 
@@ -188,7 +206,7 @@ describe Course do
         allow(SettingsService).to receive(:get_settings).and_return('course_end_time' => "11:55 PM MST")
       end
 
-      date_param = DateTime.new(2023, 10, 30, 23, 59, 0)
+      date_param = DateTime.new(2023, 10, 30, 23, 59, 0).utc
       let(:course) { Course.create(conclude_at: date_param) }
 
       it "matches end time in account settings" do


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/QTY-8461)

## Purpose 
Some courses have some incorrect start and end times. We believe we have a fix.

## Approach 
We need to take in a date and time, and return a combined date-time, while considering the time-zone of the inputed time.
We were originally not converting the time component into UTC properly.

## Testing
Unit specs for the `#create` method on the `Course` model. This allows us to test the `set_course_start_end_time_from_school` method on a `before_create` callback.


We tested creating course #3863 in new-id-sandbox and confirmed that the times are now correct.
<img width="1425" alt="image" src="https://github.com/StrongMind/canvas_shim/assets/57233323/3d5b98ac-a672-4926-acbf-342a2e309041">
