### PR TITLE
refactor-rollover-dates

### DIFF
--- a/app/decorators/models/course_decorator.rb
+++ b/app/decorators/models/course_decorator.rb
@@ -124,12 +124,13 @@ Course.class_eval do
 
   def coalesce_datetime(date:, time:)
     day_offset = utc_day_offset(time)
+    date = date + (day_offset).days
     utc_time = Time.parse(time).utc
 
     Time.new(
       date.year,
       date.month,
-      date.day + day_offset,
+      date.day,
       utc_time.hour,
       utc_time.min,
       utc_time.sec,

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -242,6 +242,53 @@ describe Course do
           it "saves the date with the correct offset" do
             expect(course.conclude_at.day).to eq(25)
           end
+
+          context 'when it is the end of the month' do
+            context 'for January' do
+              let(:course) { Course.create(conclude_at: '2025-01-31 06:59:00') }
+              let(:expected_end_date) { "2025-01-31" }
+
+              it "returns the correct date for MST" do
+                actual_end_date = course.conclude_at.in_time_zone('Arizona').strftime("%Y-%m-%d")
+                expect(actual_end_date).to eq(expected_end_date)
+              end
+
+              it "saves the date with the correct offset" do
+                expect(course.conclude_at.day).to eq(01)
+              end
+            end
+
+            context 'for February (for a non-leap year)' do
+              let(:course) { Course.create(conclude_at: '2023-02-28 06:59:00') }
+              let(:expected_end_date) { "2023-02-28" }
+
+              it "returns the correct date for MST" do
+                actual_end_date = course.conclude_at.in_time_zone('Arizona').strftime("%Y-%m-%d")
+                expect(actual_end_date).to eq(expected_end_date)
+              end
+
+              it "saves the date with the correct offset" do
+                expect(course.conclude_at.day).to eq(01)
+                expect(course.conclude_at.month).to eq(03)
+              end
+            end
+          end
+
+          context 'when it is the end of the year' do
+            let(:course) { Course.create(conclude_at: '2025-12-31 06:59:00') }
+            let(:expected_end_date) { "2025-12-31" }
+
+            it "returns the correct date for MST" do
+              actual_end_date = course.conclude_at.in_time_zone('Arizona').strftime("%Y-%m-%d")
+              expect(actual_end_date).to eq(expected_end_date)
+            end
+
+            it "saves the date with the correct offset" do
+              expect(course.conclude_at.day).to eq(01)
+              expect(course.conclude_at.year).to eq(2026)
+              expect(course.conclude_at.month).to eq(01)
+            end
+          end
         end
 
         context 'when course_end_time is in another timezone' do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -255,6 +255,7 @@ describe Course do
 
               it "saves the date with the correct offset" do
                 expect(course.conclude_at.day).to eq(01)
+                expect(course.conclude_at.month).to eq(02)
               end
             end
 
@@ -285,8 +286,8 @@ describe Course do
 
             it "saves the date with the correct offset" do
               expect(course.conclude_at.day).to eq(01)
-              expect(course.conclude_at.year).to eq(2026)
               expect(course.conclude_at.month).to eq(01)
+              expect(course.conclude_at.year).to eq(2026)
             end
           end
         end


### PR DESCRIPTION
## Purpose 
* Refactor on parsing start/conclude_at dates.
* Account for when the months/years rollover - we were getting an exception [here](https://strongmind-4j.sentry.io/issues/5585679033/?project=6262567&referrer=jira_integration) because we are trying to add a day to January 31rst and it's exploding when trying to create a day for January 32nd. I added some specs and cases for when the months/years rollover in these cases.

## Approach 
* There do not need to be two separate functions for parsing start and conclude
dates. Now we can account for date rollovers in the case that the start time is
much later in the day.
* add `offset` num of days to the date as a whole, instead of adding and `offset` number to the count of days.

## Testing
* Unit specs
