### PR TITLE
(B) QTY-9035: Changing callback to after create

### DIFF
--- a/app/decorators/models/course_decorator.rb
+++ b/app/decorators/models/course_decorator.rb
@@ -6,7 +6,7 @@ Course.class_eval do
       where("enrollments.workflow_state NOT IN ('rejected', 'deleted', 'inactive') AND enrollments.type = 'StudentEnrollment'").preload(:user)
     }, class_name: 'Enrollment'
 
-  after_create :set_course_start_end_time_from_school
+  before_create :set_course_start_end_time_from_school
 
   after_commit -> { PipelineService.publish_as_v2(self) }
   after_create -> { RequirementsService.set_school_thresholds_on_course(course: self) }

--- a/app/decorators/models/course_decorator.rb
+++ b/app/decorators/models/course_decorator.rb
@@ -108,6 +108,12 @@ Course.class_eval do
     self.conclude_at = course_end_time_from_school
   end
 
+  def update_course_with_timezone(params)
+    update(params)
+    set_course_start_end_time_from_school
+    save
+  end
+
   def course_start_time_from_school
     discern_datetime(
       date: start_at,

--- a/app/decorators/models/course_decorator.rb
+++ b/app/decorators/models/course_decorator.rb
@@ -6,7 +6,7 @@ Course.class_eval do
       where("enrollments.workflow_state NOT IN ('rejected', 'deleted', 'inactive') AND enrollments.type = 'StudentEnrollment'").preload(:user)
     }, class_name: 'Enrollment'
 
-  after_commit :set_course_start_end_time_from_school
+  after_create :set_course_start_end_time_from_school
 
   after_commit -> { PipelineService.publish_as_v2(self) }
   after_create -> { RequirementsService.set_school_thresholds_on_course(course: self) }
@@ -108,7 +108,7 @@ Course.class_eval do
     self.conclude_at = course_end_time_from_school
   end
 
-  def update_course_with_timezone(params)
+  def update_with_timezone(params)
     update(params)
     set_course_start_end_time_from_school
     save

--- a/app/decorators/models/course_decorator.rb
+++ b/app/decorators/models/course_decorator.rb
@@ -109,12 +109,6 @@ Course.class_eval do
     self
   end
 
-  def update_with_timezone(params)
-    update(params)
-    set_course_start_end_time_from_school
-    save
-  end
-
   def course_start_time_from_school
     discern_datetime(
       date: start_at,

--- a/app/decorators/models/course_decorator.rb
+++ b/app/decorators/models/course_decorator.rb
@@ -109,6 +109,10 @@ Course.class_eval do
     self
   end
 
+  def save_with_account_times
+    set_course_start_end_time_from_school.save
+  end
+
   def course_start_time_from_school
     discern_datetime(
       date: start_at,

--- a/app/decorators/models/course_decorator.rb
+++ b/app/decorators/models/course_decorator.rb
@@ -106,6 +106,7 @@ Course.class_eval do
 
     self.start_at = course_start_time_from_school
     self.conclude_at = course_end_time_from_school
+    self
   end
 
   def update_with_timezone(params)

--- a/app/views/courses/settings.html.erb
+++ b/app/views/courses/settings.html.erb
@@ -89,6 +89,7 @@
     <% opts = {:id => "course_form", :class => "formtable"} %>
     <% opts[:disabled] = 'disabled' unless can_manage %>
     <%= form_for @context, :html => opts do |f| %>
+      <%= f.hidden_field 'update_with_timezone', true %>
     <table class="coursesettings">
       <% if @context.feature_enabled?(:course_card_images) %>
       <tr>
@@ -297,7 +298,7 @@
         </td>
       </tr><tr>
       <% end %>
-      
+
       <% if available_locales.size > 1 %>
       </tr><tr>
         <td class="form-label"><%= f.blabel :locale, :language, :en => "Language" %></td>

--- a/app/views/courses/settings.html.erb
+++ b/app/views/courses/settings.html.erb
@@ -89,7 +89,7 @@
     <% opts = {:id => "course_form", :class => "formtable"} %>
     <% opts[:disabled] = 'disabled' unless can_manage %>
     <%= form_for @context, :html => opts do |f| %>
-      <%= f.hidden_field 'update_with_timezone', true %>
+      <%= hidden_field_tag :update_timezone, true %>
     <table class="coursesettings">
       <% if @context.feature_enabled?(:course_card_images) %>
       <tr>

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -377,7 +377,7 @@ describe Course do
             context 'when course_end_time is in MST' do
               before do
                 allow(SettingsService).to receive(:get_settings).and_return('course_end_time' => "11:55 PM MST")
-                course.update(conclude_at: '2025-06-24 06:59:00')
+                course.conclude_at ='2025-06-24 06:59:00'
                 course.save_with_account_times
               end
 
@@ -404,7 +404,7 @@ describe Course do
                   let(:expected_end_date) { "2025-01-31" }
 
                   before do
-                    course.update(conclude_at: '2025-01-31 06:59:00')
+                    course.conclude_at = '2025-01-31 06:59:00'
                     course.set_course_start_end_time_from_school.save
                   end
 
@@ -424,7 +424,7 @@ describe Course do
                   let(:expected_end_date) { "2023-02-28" }
 
                   before do
-                    course.update(conclude_at: '2023-02-28 06:59:00')
+                    course.conclude_at = '2023-02-28 06:59:00'
                     course.set_course_start_end_time_from_school.save
                   end
 
@@ -445,7 +445,7 @@ describe Course do
                 let(:expected_end_date) { "2025-12-31" }
 
                 before do
-                  course.update(conclude_at: '2025-12-31 06:59:00')
+                  course.conclude_at = '2025-12-31 06:59:00'
                   course.set_course_start_end_time_from_school.save
                 end
 
@@ -465,7 +465,7 @@ describe Course do
             context 'when course_end_time is in another timezone' do
               before do
                 allow(SettingsService).to receive(:get_settings).and_return('course_end_time' => "11:55 PM EDT")
-                course.update(conclude_at: '2025-06-24 06:59:00')
+                course.conclude_at = '2025-06-24 06:59:00'
                 course.save_with_account_times
 
               end
@@ -492,7 +492,7 @@ describe Course do
           context 'when the UTC date does not roll over' do
             before do
               allow(SettingsService).to receive(:get_settings).and_return('course_end_time' => "9:00 AM MST")
-              course.update(conclude_at: '2025-06-24 06:59:00')
+              course.conclude_at = '2025-06-24 06:59:00'
               course.save_with_account_times
 
             end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -369,7 +369,7 @@ describe Course do
           expect(actual_end_date).to eq(expected_end_date_after_create)
         end
       end
-      context 'when updating time zones' do
+      context 'when updating time zones using #save_with_account_times' do
         let(:course) { Course.create }
 
         context "when conclude_at is present" do
@@ -378,7 +378,7 @@ describe Course do
               before do
                 allow(SettingsService).to receive(:get_settings).and_return('course_end_time' => "11:55 PM MST")
                 course.update(conclude_at: '2025-06-24 06:59:00')
-                course.set_course_start_end_time_from_school.save
+                course.save_with_account_times
               end
 
               let(:expected_end_time) { "06:55 AM" }
@@ -466,7 +466,7 @@ describe Course do
               before do
                 allow(SettingsService).to receive(:get_settings).and_return('course_end_time' => "11:55 PM EDT")
                 course.update(conclude_at: '2025-06-24 06:59:00')
-                course.set_course_start_end_time_from_school.save
+                course.save_with_account_times
 
               end
 
@@ -493,7 +493,7 @@ describe Course do
             before do
               allow(SettingsService).to receive(:get_settings).and_return('course_end_time' => "9:00 AM MST")
               course.update(conclude_at: '2025-06-24 06:59:00')
-              course.set_course_start_end_time_from_school.save
+              course.save_with_account_times
 
             end
 

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -214,68 +214,6 @@ describe Course do
         end
       end
     end
-
-    context 'on update' do
-      let(:course) { Course.create }
-
-      context "when start_time is present" do
-        before do
-          allow(SettingsService).to receive(:get_settings).and_return('course_start_time' => "12:05 AM MST")
-          course.update!(start_at: '2025-06-24 06:59:00')
-        end
-
-        let(:expected_start_time) { "07:05 AM UTC" }
-        let(:expected_start_date) { "2025-06-24" }
-        let(:actual_start_time) { course.start_at.strftime("%H:%M %p %Z") }
-        let(:actual_start_date) { course.start_at.in_time_zone('Arizona').strftime("%Y-%m-%d") }
-
-        it "matches start time in account settings" do
-          expect(actual_start_time).to eq(expected_start_time)
-        end
-
-        it "returns the correct date for MST" do
-          expect(actual_start_date).to eq(expected_start_date)
-        end
-
-        context 'when the course has a meta-programmed time_zone' do
-          let(:time_zone) { ActiveSupport::TimeZone["America/Phoenix"] }
-
-          # canvas-lms returns an ActiveSupport::TimeZone object for the time_zone
-          before do
-            def course.time_zone
-              time_zone
-            end
-          end
-
-          it "it does not effect the saved start_at time" do
-            expect(actual_start_time).to eq(expected_start_time)
-          end
-        end
-
-        context 'with a rollover date' do
-          before do
-            allow(SettingsService).to receive(:get_settings).and_return('course_start_time' => "11:55 PM MST")
-            course.update!(start_at: '2025-06-24 06:59:00')
-          end
-
-          it "returns the correct date for MST" do
-            expect(actual_start_date).to eq(expected_start_date)
-          end
-
-          it "saves the date with the correct offset" do
-            expect(course.start_at.day).to eq(25)
-          end
-        end
-      end
-
-      context "when start_time is not present" do
-        let(:course) { Course.create() }
-        it "creates a course without a start_at" do
-          expect(course.start_at).to be nil
-        end
-      end
-
-    end
   end
 
   describe "#course_end_time_from_school" do
@@ -412,41 +350,158 @@ describe Course do
     end
 
     context 'on update' do
+      context 'when not updating time zones' do
       let(:course) { Course.create(conclude_at: '2025-06-24 06:59:00') }
 
-      before do
-        allow(SettingsService).to receive(:get_settings).and_return('course_end_time' => "11:55 PM MST")
+        before do
+          allow(SettingsService).to receive(:get_settings).and_return('course_end_time' => "11:55 PM MST")
+        end
+        let(:expected_end_time) { "06:55 AM" }
+        let(:actual_end_time) {  course.conclude_at.strftime("%H:%M %p") }
+        let(:expected_end_date_after_create) { "2025-06-25" }
+
+        it "It does not change the existing conclude_at" do
+          actual_end_date = course.conclude_at.strftime("%Y-%m-%d")
+          expect(actual_end_date).to eq(expected_end_date_after_create)
+          course.update(workflow_state: 'active')
+
+          actual_end_date = course.conclude_at.strftime("%Y-%m-%d")
+          expect(actual_end_date).to eq(expected_end_date_after_create)
+        end
       end
-      let(:expected_end_time) { "06:55 AM" }
-      let(:actual_end_time) {  course.conclude_at.strftime("%H:%M %p") }
-      let(:expected_end_date_after_create) { "2025-06-25" }
+      context 'when updating time zones' do
+        let(:course) { Course.create }
 
-      it "It does not change the existing conclude_at" do
-        actual_end_date = course.conclude_at.strftime("%Y-%m-%d")
-        expect(actual_end_date).to eq(expected_end_date_after_create)
-        course.update(workflow_state: 'active')
+        context "when conclude_at is present" do
+          context 'when the UTC date rolls over' do
+            context 'when course_end_time is in MST' do
+              before do
+                allow(SettingsService).to receive(:get_settings).and_return('course_end_time' => "11:55 PM MST")
+                course.update(conclude_at: '2025-06-24 06:59:00')
+                course.set_course_start_end_time_from_school.save
+              end
 
-        actual_end_date = course.conclude_at.strftime("%Y-%m-%d")
-        expect(actual_end_date).to eq(expected_end_date_after_create)
-      end
-    end
-  end
-  context '#update_with_timezone' do
-      let(:course) { Course.create }
+              let(:expected_end_time) { "06:55 AM" }
+              let(:actual_end_time) {  course.conclude_at.strftime("%H:%M %p") }
+              let(:expected_end_date) { "2025-06-24" }
 
-      context "when conclude_at is present" do
-        context 'when the UTC date rolls over' do
-          context 'when course_end_time is in MST' do
-            before do
-              allow(SettingsService).to receive(:get_settings).and_return('course_end_time' => "11:55 PM MST")
-              course.update_with_timezone(conclude_at: '2025-06-24 06:59:00')
+              it "matches the time in the account settings" do
+                expect(actual_end_time).to eq(expected_end_time)
+              end
+
+              it "returns the correct date for MST" do
+                actual_end_date = course.conclude_at.in_time_zone('Arizona').strftime("%Y-%m-%d")
+                expect(actual_end_date).to eq(expected_end_date)
+              end
+
+              it "saves the date with the correct offset" do
+                expect(course.conclude_at.day).to eq(25)
+              end
+
+              context 'when it is the end of the month' do
+                context 'for January' do
+                  let(:course) { Course.create }
+                  let(:expected_end_date) { "2025-01-31" }
+
+                  before do
+                    course.update(conclude_at: '2025-01-31 06:59:00')
+                    course.set_course_start_end_time_from_school.save
+                  end
+
+                  it "returns the correct date for MST" do
+                    actual_end_date = course.conclude_at.in_time_zone('Arizona').strftime("%Y-%m-%d")
+                    expect(actual_end_date).to eq(expected_end_date)
+                  end
+
+                  it "saves the date with the correct offset" do
+                    expect(course.conclude_at.day).to eq(01)
+                    expect(course.conclude_at.month).to eq(02)
+                  end
+                end
+
+                context 'for February (for a non-leap year)' do
+                  let(:course) { Course.create }
+                  let(:expected_end_date) { "2023-02-28" }
+
+                  before do
+                    course.update(conclude_at: '2023-02-28 06:59:00')
+                    course.set_course_start_end_time_from_school.save
+                  end
+
+                  it "returns the correct date for MST" do
+                    actual_end_date = course.conclude_at.in_time_zone('Arizona').strftime("%Y-%m-%d")
+                    expect(actual_end_date).to eq(expected_end_date)
+                  end
+
+                  it "saves the date with the correct offset" do
+                    expect(course.conclude_at.day).to eq(01)
+                    expect(course.conclude_at.month).to eq(03)
+                  end
+                end
+              end
+
+              context 'when it is the end of the year' do
+                let(:course) { Course.create }
+                let(:expected_end_date) { "2025-12-31" }
+
+                before do
+                  course.update(conclude_at: '2025-12-31 06:59:00')
+                  course.set_course_start_end_time_from_school.save
+                end
+
+                it "returns the correct date for MST" do
+                  actual_end_date = course.conclude_at.in_time_zone('Arizona').strftime("%Y-%m-%d")
+                  expect(actual_end_date).to eq(expected_end_date)
+                end
+
+                it "saves the date with the correct offset" do
+                  expect(course.conclude_at.day).to eq(01)
+                  expect(course.conclude_at.month).to eq(01)
+                  expect(course.conclude_at.year).to eq(2026)
+                end
+              end
             end
 
-            let(:expected_end_time) { "06:55 AM" }
-            let(:actual_end_time) {  course.conclude_at.strftime("%H:%M %p") }
+            context 'when course_end_time is in another timezone' do
+              before do
+                allow(SettingsService).to receive(:get_settings).and_return('course_end_time' => "11:55 PM EDT")
+                course.update(conclude_at: '2025-06-24 06:59:00')
+                course.set_course_start_end_time_from_school.save
+
+              end
+
+              let(:expected_end_time) { "03:55 AM" }
+              let(:expected_end_date) { "2025-06-24" }
+
+              it "matches the time in the account settings" do
+                actual_end_time = course.conclude_at.strftime("%H:%M %p")
+                expect(actual_end_time).to eq(expected_end_time)
+              end
+
+              it "returns the correct date for MST" do
+                actual_end_date = course.conclude_at.in_time_zone('Eastern Time (US & Canada)').strftime("%Y-%m-%d")
+                expect(actual_end_date).to eq(expected_end_date)
+              end
+
+              it "saves the date with the correct offset" do
+                expect(course.conclude_at.day).to eq(25)
+              end
+            end
+          end
+
+          context 'when the UTC date does not roll over' do
+            before do
+              allow(SettingsService).to receive(:get_settings).and_return('course_end_time' => "9:00 AM MST")
+              course.update(conclude_at: '2025-06-24 06:59:00')
+              course.set_course_start_end_time_from_school.save
+
+            end
+
+            let(:expected_end_time) { "16:00 PM" }
             let(:expected_end_date) { "2025-06-24" }
 
             it "matches the time in the account settings" do
+              actual_end_time = course.conclude_at.strftime("%H:%M %p")
               expect(actual_end_time).to eq(expected_end_time)
             end
 
@@ -456,178 +511,71 @@ describe Course do
             end
 
             it "saves the date with the correct offset" do
-              expect(course.conclude_at.day).to eq(25)
-            end
-
-            context 'when it is the end of the month' do
-              context 'for January' do
-                let(:course) { Course.create }
-                let(:expected_end_date) { "2025-01-31" }
-
-                before do
-                  course.update_with_timezone(conclude_at: '2025-01-31 06:59:00')
-                end
-
-                it "returns the correct date for MST" do
-                  actual_end_date = course.conclude_at.in_time_zone('Arizona').strftime("%Y-%m-%d")
-                  expect(actual_end_date).to eq(expected_end_date)
-                end
-
-                it "saves the date with the correct offset" do
-                  expect(course.conclude_at.day).to eq(01)
-                  expect(course.conclude_at.month).to eq(02)
-                end
-              end
-
-              context 'for February (for a non-leap year)' do
-                let(:course) { Course.create }
-                let(:expected_end_date) { "2023-02-28" }
-
-                before do
-                  course.update_with_timezone(conclude_at: '2023-02-28 06:59:00')
-                end
-
-                it "returns the correct date for MST" do
-                  actual_end_date = course.conclude_at.in_time_zone('Arizona').strftime("%Y-%m-%d")
-                  expect(actual_end_date).to eq(expected_end_date)
-                end
-
-                it "saves the date with the correct offset" do
-                  expect(course.conclude_at.day).to eq(01)
-                  expect(course.conclude_at.month).to eq(03)
-                end
-              end
-            end
-
-            context 'when it is the end of the year' do
-              let(:course) { Course.create }
-              let(:expected_end_date) { "2025-12-31" }
-
-              before do
-                course.update_with_timezone(conclude_at: '2025-12-31 06:59:00')
-              end
-
-              it "returns the correct date for MST" do
-                actual_end_date = course.conclude_at.in_time_zone('Arizona').strftime("%Y-%m-%d")
-                expect(actual_end_date).to eq(expected_end_date)
-              end
-
-              it "saves the date with the correct offset" do
-                expect(course.conclude_at.day).to eq(01)
-                expect(course.conclude_at.month).to eq(01)
-                expect(course.conclude_at.year).to eq(2026)
-              end
+              expect(course.conclude_at.day).to eq(24)
             end
           end
+        end
 
-          context 'when course_end_time is in another timezone' do
+        context "when set_course_start_end_time_from_school is not called" do
+          context 'when the the school time is in MST' do
+            let(:course) { Course.create(conclude_at: '2025-06-24 06:59:00') }
+
             before do
-              allow(SettingsService).to receive(:get_settings).and_return('course_end_time' => "11:55 PM EDT")
-              course.update_with_timezone(conclude_at: '2025-06-24 06:59:00')
+              allow(SettingsService).to receive(:get_settings).and_return('course_end_time' => "11:55 PM MST")
             end
+            let(:expected_end_time) { "06:55 AM" }
+            let(:actual_end_time) {  course.conclude_at.strftime("%H:%M %p") }
+            let(:expected_end_date) { "2025-06-25" }
 
-            let(:expected_end_time) { "03:55 AM" }
-            let(:expected_end_date) { "2025-06-24" }
+            it "does change the existing conclude_at" do
+              actual_end_date = course.conclude_at.strftime("%Y-%m-%d")
+              expect(actual_end_date).to eq(expected_end_date)
+              course.update(workflow_state: 'active')
 
-            it "matches the time in the account settings" do
-              actual_end_time = course.conclude_at.strftime("%H:%M %p")
-              expect(actual_end_time).to eq(expected_end_time)
-            end
-
-            it "returns the correct date for MST" do
-              actual_end_date = course.conclude_at.in_time_zone('Eastern Time (US & Canada)').strftime("%Y-%m-%d")
+              actual_end_date = course.conclude_at.strftime("%Y-%m-%d")
               expect(actual_end_date).to eq(expected_end_date)
             end
+          end
+          context 'when the school time is in UTC' do
+            let(:course) { Course.create(conclude_at: '2025-06-24 06:59:00') }
 
-            it "saves the date with the correct offset" do
-              expect(course.conclude_at.day).to eq(25)
+            before do
+              allow(SettingsService).to receive(:get_settings).and_return('course_end_time' => "11:55 PM UTC")
+            end
+            let(:expected_end_time) { "06:55 AM" }
+            let(:actual_end_time) {  course.conclude_at.strftime("%H:%M %p") }
+            let(:expected_end_date) { "2025-06-24" }
+
+            it "It does not change the existing conclude_at" do
+              actual_end_date = course.conclude_at.strftime("%Y-%m-%d")
+              expect(actual_end_date).to eq(expected_end_date)
+              course.update(workflow_state: 'active')
+
+              actual_end_date = course.conclude_at.strftime("%Y-%m-%d")
+              expect(actual_end_date).to eq(expected_end_date)
+            end
+          end
+          context 'when the the school time is in MDT' do
+            let(:course) { Course.create(conclude_at: '2025-06-24 06:59:00') }
+
+            before do
+              allow(SettingsService).to receive(:get_settings).and_return('course_end_time' => "11:55 PM MDT")
+            end
+            let(:expected_end_time) { "06:55 AM" }
+            let(:actual_end_time) {  course.conclude_at.strftime("%H:%M %p") }
+            let(:expected_end_date) { "2025-06-25" }
+
+            it "does change the existing conclude_at" do
+              actual_end_date = course.conclude_at.strftime("%Y-%m-%d")
+              expect(actual_end_date).to eq(expected_end_date)
+              course.update(workflow_state: 'active')
+
+              actual_end_date = course.conclude_at.strftime("%Y-%m-%d")
+              expect(actual_end_date).to eq(expected_end_date)
             end
           end
         end
-
-        context 'when the UTC date does not roll over' do
-          before do
-            allow(SettingsService).to receive(:get_settings).and_return('course_end_time' => "9:00 AM MST")
-            course.update_with_timezone(conclude_at: '2025-06-24 06:59:00')
-          end
-
-          let(:expected_end_time) { "16:00 PM" }
-          let(:expected_end_date) { "2025-06-24" }
-
-          it "matches the time in the account settings" do
-            actual_end_time = course.conclude_at.strftime("%H:%M %p")
-            expect(actual_end_time).to eq(expected_end_time)
-          end
-
-          it "returns the correct date for MST" do
-            actual_end_date = course.conclude_at.in_time_zone('Arizona').strftime("%Y-%m-%d")
-            expect(actual_end_date).to eq(expected_end_date)
-          end
-
-          it "saves the date with the correct offset" do
-            expect(course.conclude_at.day).to eq(24)
-          end
-        end
       end
-
-      context "when conclude_at is not present in update" do
-        context 'when the the school time is in MST' do
-          let(:course) { Course.create(conclude_at: '2025-06-24 06:59:00') }
-
-          before do
-            allow(SettingsService).to receive(:get_settings).and_return('course_end_time' => "11:55 PM MST")
-          end
-          let(:expected_end_time) { "06:55 AM" }
-          let(:actual_end_time) {  course.conclude_at.strftime("%H:%M %p") }
-          let(:expected_end_date) { "2025-06-25" }
-
-          it "does change the existing conclude_at" do
-            actual_end_date = course.conclude_at.strftime("%Y-%m-%d")
-            expect(actual_end_date).to eq(expected_end_date)
-            course.update(workflow_state: 'active')
-
-            actual_end_date = course.conclude_at.strftime("%Y-%m-%d")
-            expect(actual_end_date).to eq(expected_end_date)
-          end
-        end
-        context 'when the school time is in UTC' do
-          let(:course) { Course.create(conclude_at: '2025-06-24 06:59:00') }
-
-          before do
-            allow(SettingsService).to receive(:get_settings).and_return('course_end_time' => "11:55 PM UTC")
-          end
-          let(:expected_end_time) { "06:55 AM" }
-          let(:actual_end_time) {  course.conclude_at.strftime("%H:%M %p") }
-          let(:expected_end_date) { "2025-06-24" }
-
-          it "It does not change the existing conclude_at" do
-            actual_end_date = course.conclude_at.strftime("%Y-%m-%d")
-            expect(actual_end_date).to eq(expected_end_date)
-            course.update_with_timezone(workflow_state: 'active')
-
-            actual_end_date = course.conclude_at.strftime("%Y-%m-%d")
-            expect(actual_end_date).to eq(expected_end_date)
-          end
-        end
-        context 'when the the school time is in MDT' do
-          let(:course) { Course.create(conclude_at: '2025-06-24 06:59:00') }
-
-          before do
-            allow(SettingsService).to receive(:get_settings).and_return('course_end_time' => "11:55 PM MDT")
-          end
-          let(:expected_end_time) { "06:55 AM" }
-          let(:actual_end_time) {  course.conclude_at.strftime("%H:%M %p") }
-          let(:expected_end_date) { "2025-06-25" }
-
-          it "does change the existing conclude_at" do
-            actual_end_date = course.conclude_at.strftime("%Y-%m-%d")
-            expect(actual_end_date).to eq(expected_end_date)
-            course.update(workflow_state: 'active')
-
-            actual_end_date = course.conclude_at.strftime("%Y-%m-%d")
-            expect(actual_end_date).to eq(expected_end_date)
-          end
-        end
-      end
+    end
   end
 end


### PR DESCRIPTION
[QTY-9035](https://strongmind.atlassian.net/browse/QTY-9035)

## Purpose 
Course updates were causing course conclude dates to changes dates depending on their timezone.

## Approach 
Pass param in frontend to manually calculate timezones

## Testing
Rspec, Local testing on teamviewer VM


[QTY-9035]: https://strongmind.atlassian.net/browse/QTY-9035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ