### PR TITLE
PLT-13623: Reduce complexity of "keep highest score" feature to improve performance

### DIFF
--- a/app/decorators/lib/basic_lti/basic_outcomes_decorator.rb
+++ b/app/decorators/lib/basic_lti/basic_outcomes_decorator.rb
@@ -4,6 +4,12 @@ BasicLTI::BasicOutcomes::LtiResponse.class_eval do
   alias_method :homework_submission_alias, :create_homework_submission
 
   def create_homework_submission(_tool, submission_hash, assignment, user, new_score, raw_score)
+    submissions = assignment.all_submissions.where(user_id: user.id)
+    if submissions.present?
+      @current_score = submissions.last.score
+      @current_grade = submissions.last.grade
+    end
+
     homework_submission_alias(_tool, submission_hash, assignment, user, new_score, raw_score)
 
     if SettingsService.get_settings(object: :school, id: 1)['lti_keep_highest_score']
@@ -28,18 +34,8 @@ BasicLTI::BasicOutcomes::LtiResponse.class_eval do
     return unless @submission
     return if @submission.excused?
 
-    best_score = @submission.score
-    best_grade = @submission.grade
-    versions   = @submission.versions
-
-    versions.each do |version|
-      version_score = YAML.load(version.yaml).stringify_keys['score']
-      if version_score.to_f > best_score.to_f
-        best_score = version_score
-        best_grade = YAML.load(version.yaml).stringify_keys['grade']
-      end
+    if @current_score.present? && @current_score.to_f > @submission.score.to_f
+      @submission.update_columns({ score: @current_score, grade: @current_grade, published_grade: @current_grade, published_score: @current_score })
     end
-
-    @submission.update_columns({score: best_score, grade: best_grade, published_grade: best_grade, published_score: best_score})
   end
 end

--- a/app/decorators/lib/basic_lti/basic_outcomes_decorator.rb
+++ b/app/decorators/lib/basic_lti/basic_outcomes_decorator.rb
@@ -33,8 +33,9 @@ BasicLTI::BasicOutcomes::LtiResponse.class_eval do
   def update_submission_with_best_score
     return unless @submission
     return if @submission.excused?
+    return unless @current_score.present?
 
-    if @current_score.present? && @current_score.to_f > @submission.score.to_f
+    if @current_score.to_f > @submission.score.to_f
       @submission.update_columns({ score: @current_score, grade: @current_grade, published_grade: @current_grade, published_score: @current_score })
     end
   end

--- a/db/migrate/20241114205608_add_published_grade_and_score_to_submission.rb
+++ b/db/migrate/20241114205608_add_published_grade_and_score_to_submission.rb
@@ -1,0 +1,6 @@
+class AddPublishedGradeAndScoreToSubmission < ActiveRecord::Migration[5.0]
+  def change
+    add_column :submissions, :published_grade, :string
+    add_column :submissions, :published_score, :float
+  end
+end

--- a/spec/lib/basic_lti/basic_outcomes/lti_response_spec.rb
+++ b/spec/lib/basic_lti/basic_outcomes/lti_response_spec.rb
@@ -3,12 +3,20 @@ describe BasicLTI::BasicOutcomes::LtiResponse do
   describe '#create_homework_submission' do
     context 'featured' do
       let(:submission) do
-        Submission.create(excused: false, versions: [version, version2, version3], score: 10, grade: 10)
+        Submission.create(excused: false, versions: [version, version2, version3], score: 100, grade: 100)
       end
 
-      let(:version) { SubmissionVersion.create(yaml: {score: 100, grade: 100, excused: false}.to_yaml) }
-      let(:version2) { SubmissionVersion.create(yaml: {score: 90, grade: 90, excused: false}.to_yaml) }
-      let(:version3) { SubmissionVersion.create(yaml: {score: 80, grade: 80, excused: false}.to_yaml) }
+      let(:version) { SubmissionVersion.create(yaml: { score: 100, grade: 100, excused: false }.to_yaml) }
+      let(:version2) { SubmissionVersion.create(yaml: { score: 90, grade: 90, excused: false }.to_yaml) }
+      let(:version3) { SubmissionVersion.create(yaml: { score: 80, grade: 80, excused: false }.to_yaml) }
+
+      let(:tool_id) { Faker::Number.number(digits: 10) }
+      let(:submission_hash) { Faker::Number.number(digits: 10) }
+      let(:assignment) { Faker::Number.number(digits: 10) }
+      let(:user) { Faker::Number.number(digits: 10) }
+      let(:score) { Faker::Number.between(from: 0, to: 100) }
+      let(:new_score) { score }
+      let(:raw_score) { score }
 
       before do
         allow(PipelineService).to receive(:publish)
@@ -18,24 +26,59 @@ describe BasicLTI::BasicOutcomes::LtiResponse do
 
       it 'should call the shimmed method' do
         expect(subject).to receive(:update_submission_with_best_score)
-        subject.create_homework_submission(1,2,3,4,5,6)
+        subject.create_homework_submission(1, 2, 3, 4, 5, 6)
       end
 
       it 'sets the score and grade to the highest in the submission history' do
-        expect(submission).to receive(:update_columns).with({grade: 100, score: 100, published_grade: 100, published_score: 100})
-        subject.create_homework_submission(1,2,3,4,5,6)
+        expect(submission).to receive(:update_columns).with({ grade: 100, score: 100, published_grade: 100, published_score: 100 })
+        subject.create_homework_submission(1, 2, 3, 4, 5, 6)
       end
 
-      context "no submission" do
+      context "when there are no previous submissions" do
+
+
         before do
           subject.instance_variable_set('@submission', nil)
         end
 
         it 'wont update' do
           expect(submission).to_not receive(:update)
-          subject.create_homework_submission(1,2,3,4,5,6)
+          subject.create_homework_submission(tool_id, submission_hash, assignment, user, new_score, raw_score)
+        end
+
+        it 'has the saved score' do
+          subject.create_homework_submission(tool_id, submission_hash, assignment, user, new_score, raw_score)
+          expect(submission.reload.score).to eq(score)
         end
       end
+
+      context 'when there is a previous submission' do
+        let(:higher_score) { Faker::Number.between(from: 51, to: 100) }
+        let(:lower_score) { Faker::Number.between(from: 0, to: 50) }
+
+        context 'when the previous submission score is higher than the new score' do
+          let(:submission) do
+            Submission.create(excused: false, versions: [version, version2, version3], score: higher_score, grade: higher_score)
+          end
+
+          it 'updates the submission score with the previous submission score' do
+            subject.create_homework_submission(tool_id, submission_hash, assignment, user, lower_score, lower_score)
+            expect(submission.reload.score).to eq(higher_score)
+          end
+        end
+
+        context 'when the previous submission score is lower than the new score' do
+          let(:submission) do
+            Submission.create(excused: false, versions: [version, version2, version3], score: lower_score, grade: lower_score)
+          end
+
+          it 'does not update the submission score' do
+            subject.create_homework_submission(tool_id, submission_hash, assignment, user, higher_score, higher_score)
+            expect(submission.reload.score).to eq(higher_score)
+          end
+        end
+      end
+
     end
 
     context 'unfeatured' do
@@ -45,7 +88,7 @@ describe BasicLTI::BasicOutcomes::LtiResponse do
 
       it 'should not call the shimmed method' do
         expect(subject).to_not receive(:update_submission_with_best_score)
-        subject.create_homework_submission(1,2,3,4,5,6)
+        subject.create_homework_submission(1, 2, 3, 4, 5, 6)
       end
     end
 
@@ -58,7 +101,7 @@ describe BasicLTI::BasicOutcomes::LtiResponse do
       end
       it 'wont update' do
         expect(submission).to_not receive(:update)
-        subject.create_homework_submission(1,2,3,4,5,6)
+        subject.create_homework_submission(1, 2, 3, 4, 5, 6)
       end
     end
 

--- a/spec/lib/basic_lti/basic_outcomes/lti_response_spec.rb
+++ b/spec/lib/basic_lti/basic_outcomes/lti_response_spec.rb
@@ -1,5 +1,15 @@
 describe BasicLTI::BasicOutcomes::LtiResponse do
+  include_context 'stubbed_network'
+
   subject { described_class.new }
+  let(:sqs_instance) { double('sqs_instance') }
+
+  before do
+    allow(SettingsService).to receive(:get_settings).and_return(
+      'pipeline_sqs_url' => 'sqs_url'
+    )
+    allow(Aws::SQS::Client).to receive(:new).and_return(sqs_instance)
+  end
 
   describe '#create_homework_submission' do
     let(:tool_id) { Faker::Number.number(10) }

--- a/spec/lib/basic_lti/basic_outcomes/lti_response_spec.rb
+++ b/spec/lib/basic_lti/basic_outcomes/lti_response_spec.rb
@@ -14,8 +14,8 @@ describe BasicLTI::BasicOutcomes::LtiResponse do
   describe '#create_homework_submission' do
     let(:tool_id) { Faker::Number.number(10) }
     let(:submission_hash) { Faker::Number.number(10) }
-    let(:assignment) { Assignment.first }
-    let(:submission) { Submission.first }
+    let(:assignment) { Assignment.create(assignment_group: AssignmentGroup.create) }
+    let(:submission) { Submission.create(assignment: assignment, user: user) }
     let(:user) { User.create }
     let(:score) { Faker::Number.between(0, 100) }
     let(:new_score) { score }

--- a/spec/test_app/app/models/assignment.rb
+++ b/spec/test_app/app/models/assignment.rb
@@ -1,6 +1,7 @@
 class Assignment < ActiveRecord::Base
   has_many :submissions
   has_many :assignment_overrides
+  has_many :all_submissions, class_name: "Submission"
   has_one :discussion_topic
   belongs_to :context, class_name: 'Course'
   belongs_to :course

--- a/spec/test_app/db/schema.rb
+++ b/spec/test_app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20241112214216) do
+ActiveRecord::Schema.define(version: 20241114205608) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -291,6 +291,8 @@ ActiveRecord::Schema.define(version: 20241112214216) do
     t.string   "context_code"
     t.datetime "created_at"
     t.text     "body"
+    t.string   "published_grade"
+    t.float    "published_score"
   end
 
   create_table "user_notes", force: :cascade do |t|

--- a/spec/test_app/lib/basic_lti/basic_outcomes.rb
+++ b/spec/test_app/lib/basic_lti/basic_outcomes.rb
@@ -2,10 +2,19 @@ module BasicLTI
   module BasicOutcomes
     class LtiResponse
       def create_homework_submission(_tool, submission_hash, assignment, user, new_score, raw_score)
+        if @submission.present?
+          @submission.score = new_score
+          @submission.save
+        else
+          Submission.create(
+            score: new_score,
+            user: user,
+            assignment: assignment
+          )
+        end
       end
 
-      def handle_replaceResult(_tool, _course, assignment, user)
-      end
+      def handle_replaceResult(_tool, _course, assignment, user) end
     end
   end
 end


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/PLT-13623)

## Purpose 
<!-- what/why -->
Learnosity Player is getting 504s due to grade passback in canvas being slow. We think this may be due to the "keep highest score" feature in the canvas shim. The implementation looped over every version to find the highest and parsed the YAML twice for each version. 

## Approach 
<!-- how -->
Rather than looping over versions, we are simply querying before we submit to see what the current submission score is. If the new score is higher, we do nothing. If the current score is lower, we update the score and grade columns to equal the previous score/grade.

## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
Added new specs to verify actual functionality. Made the test app do a more realistic implementation of the create_homework_submission method.
