### PR TITLE
Qty 10001: Add support for MT time by mapping to America/Denver

### DIFF
--- a/app/decorators/models/course_decorator.rb
+++ b/app/decorators/models/course_decorator.rb
@@ -144,10 +144,19 @@ Course.class_eval do
   end
 
   def utc_day_offset(time)
-    parsed_in_zone = Time.parse(time)
-    hour_offset = (parsed_in_zone.utc_offset / 3_600) * -1
+    hour_offset = utc_hour_offset(time)
     rollover_limit = 24 - hour_offset
     parsed_in_zone.hour >= rollover_limit ? 1 : 0
+  end
+
+  def utc_hour_offset(time)
+    school_timezone = SettingsService.get_settings(object: 'school', id: 1)['timezone']
+    custom_timezones = {
+      'MT' => ActiveSupport::TimeZone['America/Denver'],
+    }
+    parsed_in_zone = Time.parse(time)
+    # parsed_in_zone = custom_timezones[school_timezone] ? custom_timezones[school_timezone].parse(time) : Time.parse(time)
+    (parsed_in_zone.utc_offset / 3_600) * -1
   end
 
   def course_end_time_from_school

--- a/app/decorators/models/course_decorator.rb
+++ b/app/decorators/models/course_decorator.rb
@@ -154,8 +154,7 @@ Course.class_eval do
     custom_timezones = {
       'MT' => ActiveSupport::TimeZone['America/Denver'],
     }
-    parsed_in_zone = Time.parse(time)
-    # parsed_in_zone = custom_timezones[school_timezone] ? custom_timezones[school_timezone].parse(time) : Time.parse(time)
+    parsed_in_zone = custom_timezones[school_timezone] ? custom_timezones[school_timezone].parse(time) : Time.parse(time)
     (parsed_in_zone.utc_offset / 3_600) * -1
   end
 

--- a/app/decorators/models/course_decorator.rb
+++ b/app/decorators/models/course_decorator.rb
@@ -144,18 +144,18 @@ Course.class_eval do
   end
 
   def utc_day_offset(time)
-    hour_offset = utc_hour_offset(time)
+    parsed_in_zone = parse_time_in_zone(time)
+    hour_offset = (parsed_in_zone.utc_offset / 3_600) * -1
     rollover_limit = 24 - hour_offset
     parsed_in_zone.hour >= rollover_limit ? 1 : 0
   end
 
-  def utc_hour_offset(time)
+  def parse_time_in_zone(time)
     school_timezone = SettingsService.get_settings(object: 'school', id: 1)['timezone']
     custom_timezones = {
       'MT' => ActiveSupport::TimeZone['America/Denver'],
     }
-    parsed_in_zone = custom_timezones[school_timezone] ? custom_timezones[school_timezone].parse(time) : Time.parse(time)
-    (parsed_in_zone.utc_offset / 3_600) * -1
+    custom_timezones[school_timezone] ? custom_timezones[school_timezone].parse(time) : Time.parse(time)
   end
 
   def course_end_time_from_school

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -579,19 +579,17 @@ describe Course do
     end
   end
 
-  describe '#utc_hour_offset' do
+  describe '#parse_time_in_zone' do
     let(:course) { Course.create }
     context 'when the time is in MT' do
       before do
         allow(SettingsService).to receive(:get_settings).and_return('timezone' => 'MT')
       end
-      it 'returns 6 when observing daylight savings' do
-        expect(course.utc_hour_offset('Sat, 5 Oct 2024 1:00 AM MT')).to eq(6)
+      it 'returns the correct date with an offset of 6 when observing daylight savings' do
+        expect(course.parse_time_in_zone('Sat, 5 Oct 2024 1:00 AM MT')).to eq('2024-10-05 01:00:00.000000000 -0600')
       end
-      it 'returns 7 when not observing daylight savings' do
-        Time.use_zone('UTC') do
-          expect(course.utc_hour_offset('Sat, 5 Nov 2024 1:00 AM MT')).to eq(7)
-        end
+      it 'returns the correct date with an offset of 7 when not observing daylight savings' do
+          expect(course.parse_time_in_zone('Sat, 5 Nov 2024 1:00 AM MT')).to eq('2024-11-05 01:00:00.000000000 -0700')
       end
     end
   end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -578,4 +578,21 @@ describe Course do
       end
     end
   end
+
+  describe '#utc_hour_offset' do
+    let(:course) { Course.create }
+    context 'when the time is in MT' do
+      before do
+        allow(SettingsService).to receive(:get_settings).and_return('timezone' => 'MT')
+      end
+      it 'returns 6 when observing daylight savings' do
+        expect(course.utc_hour_offset('Sat, 5 Oct 2024 1:00 AM MT')).to eq(6)
+      end
+      it 'returns 7 when not observing daylight savings' do
+        Time.use_zone('UTC') do
+          expect(course.utc_hour_offset('Sat, 5 Nov 2024 1:00 AM MT')).to eq(7)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/QTY-10001)

## Purpose 
User's are experiencing a bug where times in MDT are being converted to MST.

## Approach 
Add MT as a custom timezone that maps to ActiveSupport, America/Denver.

## Testing
Specs
