### PR TITLE
(B) QTY-10001: Include date when determining UTC offset

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,8 +59,8 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
+    addressable (2.8.4)
+      public_suffix (>= 2.0.2, < 6.0)
     arel (7.1.4)
     awesome_print (1.9.2)
     aws-eventstream (1.2.0)
@@ -112,7 +112,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.3.4)
+    concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -126,7 +126,7 @@ GEM
       delayed_job (>= 3.0, < 5)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
-    diff-lcs (1.5.1)
+    diff-lcs (1.5.0)
     digest (3.1.1)
     dotenv (2.8.1)
     dotenv-rails (2.8.1)
@@ -148,9 +148,9 @@ GEM
     faraday (0.17.6)
       multipart-post (>= 1.2, < 3)
     ffi (1.15.5)
-    footrest (0.5.8)
+    footrest (0.5.5)
       activesupport (>= 3.0.0)
-      faraday (>= 0.9.0, < 2)
+      faraday (>= 0.9.0, < 1)
       link_header (>= 0.0.7)
     globalid (1.1.0)
       activesupport (>= 5.0)
@@ -167,7 +167,6 @@ GEM
     jmespath (1.6.2)
     json (2.6.3)
     link_header (0.0.8)
-    logger (1.6.1)
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -177,13 +176,12 @@ GEM
       net-pop
       net-smtp
     method_source (0.9.2)
-    mime-types (3.6.0)
-      logger
+    mime-types (3.4.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2023.0218.1)
     mini_mime (1.1.2)
     mini_portile2 (2.8.2)
-    minitest (5.25.2)
+    minitest (5.15.0)
     multi_xml (0.6.0)
     multipart-post (2.3.0)
     net-imap (0.2.2)
@@ -200,16 +198,16 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.9)
-    nokogiri (1.13.10-x86_64-darwin)
+    nokogiri (1.16.2-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.10-x86_64-linux)
+    nokogiri (1.16.2-x86_64-linux)
       racc (~> 1.4)
     pandarus (0.7.0)
       activesupport (~> 5.0)
       footrest (~> 0.5.0)
       inflecto (~> 0.0)
       virtus (~> 1.0)
-    pg (1.5.9)
+    pg (1.5.3)
     pipeline_publisher_ruby (1.0.3)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
@@ -238,9 +236,8 @@ GEM
       bundler (>= 1.3.0)
       railties (= 5.0.7.2)
       sprockets-rails (>= 2.0.0)
-    rails-dom-testing (2.2.0)
-      activesupport (>= 5.0.0)
-      minitest
+    rails-dom-testing (2.0.3)
+      activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.5.0)
       loofah (~> 2.19, >= 2.19.1)
@@ -334,7 +331,6 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
-  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,8 +59,8 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    addressable (2.8.4)
-      public_suffix (>= 2.0.2, < 6.0)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     arel (7.1.4)
     awesome_print (1.9.2)
     aws-eventstream (1.2.0)
@@ -112,7 +112,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.2.2)
+    concurrent-ruby (1.3.4)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -126,7 +126,7 @@ GEM
       delayed_job (>= 3.0, < 5)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
-    diff-lcs (1.5.0)
+    diff-lcs (1.5.1)
     digest (3.1.1)
     dotenv (2.8.1)
     dotenv-rails (2.8.1)
@@ -148,9 +148,9 @@ GEM
     faraday (0.17.6)
       multipart-post (>= 1.2, < 3)
     ffi (1.15.5)
-    footrest (0.5.5)
+    footrest (0.5.8)
       activesupport (>= 3.0.0)
-      faraday (>= 0.9.0, < 1)
+      faraday (>= 0.9.0, < 2)
       link_header (>= 0.0.7)
     globalid (1.1.0)
       activesupport (>= 5.0)
@@ -167,6 +167,7 @@ GEM
     jmespath (1.6.2)
     json (2.6.3)
     link_header (0.0.8)
+    logger (1.6.1)
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -176,12 +177,13 @@ GEM
       net-pop
       net-smtp
     method_source (0.9.2)
-    mime-types (3.4.1)
+    mime-types (3.6.0)
+      logger
       mime-types-data (~> 3.2015)
     mime-types-data (3.2023.0218.1)
     mini_mime (1.1.2)
     mini_portile2 (2.8.2)
-    minitest (5.15.0)
+    minitest (5.25.2)
     multi_xml (0.6.0)
     multipart-post (2.3.0)
     net-imap (0.2.2)
@@ -198,16 +200,16 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.9)
-    nokogiri (1.16.2-x86_64-darwin)
+    nokogiri (1.13.10-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.2-x86_64-linux)
+    nokogiri (1.13.10-x86_64-linux)
       racc (~> 1.4)
     pandarus (0.7.0)
       activesupport (~> 5.0)
       footrest (~> 0.5.0)
       inflecto (~> 0.0)
       virtus (~> 1.0)
-    pg (1.5.3)
+    pg (1.5.9)
     pipeline_publisher_ruby (1.0.3)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
@@ -236,8 +238,9 @@ GEM
       bundler (>= 1.3.0)
       railties (= 5.0.7.2)
       sprockets-rails (>= 2.0.0)
-    rails-dom-testing (2.0.3)
-      activesupport (>= 4.2.0)
+    rails-dom-testing (2.2.0)
+      activesupport (>= 5.0.0)
+      minitest
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.5.0)
       loofah (~> 2.19, >= 2.19.1)
@@ -331,6 +334,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/app/decorators/models/course_decorator.rb
+++ b/app/decorators/models/course_decorator.rb
@@ -136,7 +136,8 @@ Course.class_eval do
       'ET' => ActiveSupport::TimeZone['America/New_York'],
       'UTC' => ActiveSupport::TimeZone['UTC']
     }
-    custom_timezones[school_timezone] ? custom_timezones[school_timezone].parse(datetime) : Time.parse(datetime)
+    # Need to support all timezones rather than default to Phoenix
+    custom_timezones[school_timezone] ? custom_timezones[school_timezone].parse(datetime) : ActiveSupport::TimeZone['America/Phoenix'].parse(datetime)
   end
 
   def course_end_time_from_school

--- a/app/decorators/models/course_decorator.rb
+++ b/app/decorators/models/course_decorator.rb
@@ -124,17 +124,7 @@ Course.class_eval do
     return nil if date.nil?
     return date if time.nil?
 
-    date_time_in_utc = parse_time_in_school_timezone(time, date).utc
-
-    Time.new(
-      date_time_in_utc.year,
-      date_time_in_utc.month,
-      date_time_in_utc.day,
-      date_time_in_utc.hour,
-      date_time_in_utc.min,
-      date_time_in_utc.sec,
-      '+00:00'
-    )
+    parse_time_in_school_timezone(time, date).utc
   end
 
   def parse_time_in_school_timezone(time, date)

--- a/app/decorators/models/course_decorator.rb
+++ b/app/decorators/models/course_decorator.rb
@@ -124,34 +124,22 @@ Course.class_eval do
     return nil if date.nil?
     return date if time.nil?
 
-    coalesce_datetime(date: date, time: time)
-  end
-
-  def coalesce_datetime(date:, time:)
-    day_offset = utc_day_offset(time, date)
-    utc_time = parse_time_in_zone(time, date).utc
-    date = date + (day_offset).days
+    date_time_in_utc = parse_time_in_school_timezone(time, date).utc
 
     Time.new(
-      date.year,
-      date.month,
-      date.day,
-      utc_time.hour,
-      utc_time.min,
-      utc_time.sec,
+      date_time_in_utc.year,
+      date_time_in_utc.month,
+      date_time_in_utc.day,
+      date_time_in_utc.hour,
+      date_time_in_utc.min,
+      date_time_in_utc.sec,
       '+00:00'
     )
   end
 
-  def utc_day_offset(time, date)
-    parsed_in_zone = parse_time_in_zone(time, date)
-    hour_offset = (parsed_in_zone.utc_offset / 3_600) * -1
-    rollover_limit = 24 - hour_offset
-    parsed_in_zone.hour >= rollover_limit ? 1 : 0
-  end
-
-  def parse_time_in_zone(time, date)
-    datetime = "#{date.to_date} #{time.split(' ')[0..1].join(' ')}"
+  def parse_time_in_school_timezone(time, date)
+    course_time_without_zone = time.split(' ')[0..1].join(' ')
+    datetime = "#{date.to_date} #{course_time_without_zone}"
     school_timezone = SettingsService.get_settings(object: 'school', id: 1)['timezone']
     custom_timezones = {
       'MT' => ActiveSupport::TimeZone['America/Denver'],

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -604,17 +604,17 @@ describe Course do
     end
   end
 
-  describe '#parse_time_in_zone' do
+  describe '#parse_time_in_school_timezone' do
     let(:course) { Course.create }
     context 'when the time is in MT' do
       before do
         allow(SettingsService).to receive(:get_settings).and_return('timezone' => 'MT')
       end
       it 'returns the correct date with an offset of 6 when observing daylight savings' do
-        expect(course.parse_time_in_zone('1:00 AM MDT', '2024-10-05 06:59:00 UTC')).to eq('2024-10-05 01:00:00.000000000 -0600')
+        expect(course.parse_time_in_school_timezone('1:00 AM MDT', '2024-10-05 06:59:00 UTC')).to eq('2024-10-05 01:00:00.000000000 -0600')
       end
       it 'returns the correct date with an offset of 7 when not observing daylight savings' do
-          expect(course.parse_time_in_zone('1:00 AM MDT', '2024-11-05 06:59:00 UTC')).to eq('2024-11-05 01:00:00.000000000 -0700')
+          expect(course.parse_time_in_school_timezone('1:00 AM MDT', '2024-11-05 06:59:00 UTC')).to eq('2024-11-05 01:00:00.000000000 -0700')
       end
     end
   end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -295,7 +295,7 @@ describe Course do
 
           context 'when course_end_time is in another timezone' do
             before do
-              allow(SettingsService).to receive(:get_settings).and_return('course_end_time' => "11:55 PM EDT")
+              allow(SettingsService).to receive(:get_settings).and_return('course_end_time' => "11:55 PM EDT", 'timezone' => "ET")
             end
 
             let(:expected_end_time) { "03:55 AM" }
@@ -313,6 +313,33 @@ describe Course do
 
             it "saves the date with the correct offset" do
               expect(course.conclude_at.day).to eq(25)
+            end
+          end
+
+          context 'when SettingsService course_end_time is in a daylight savings timezone' do
+            before do
+              allow(SettingsService).to receive(:get_settings).and_return(
+                'course_end_time' => "11:59 PM MDT",
+                'timezone' => "MT"
+              )
+            end
+
+            context 'when the course concludes at a time when daylight savings is not observed' do
+              let(:course_concluding_during_standard_time) { Course.create(conclude_at: '2025-1-10 01:23:45' ) }
+
+              it 'returns the standard time-zone time' do
+                actual_end_time = course_concluding_during_standard_time.conclude_at.strftime("%H:%M %p")
+                expect(actual_end_time).to eq("06:59 AM")
+              end
+            end
+
+            context 'when the course concludes at a time when daylight savings is observed' do
+              let(:course_concluding_during_daylight_time) { Course.create(conclude_at: '2024-10-28 01:23:45' ) }
+
+              it 'returns the daylight time-zone time' do
+                actual_end_time = course_concluding_during_daylight_time.conclude_at.strftime("%H:%M %p")
+                expect(actual_end_time).to eq("05:59 AM")
+              end
             end
           end
         end
@@ -464,7 +491,7 @@ describe Course do
 
             context 'when course_end_time is in another timezone' do
               before do
-                allow(SettingsService).to receive(:get_settings).and_return('course_end_time' => "11:55 PM EDT")
+                allow(SettingsService).to receive(:get_settings).and_return('course_end_time' => "11:55 PM EDT", 'timezone' => "ET")
                 course.conclude_at = '2025-06-24 06:59:00'
                 course.save_with_account_times
 
@@ -516,6 +543,7 @@ describe Course do
           end
         end
 
+        # This context does not seem to describe the current behavior
         context "when set_course_start_end_time_from_school is not called" do
           context 'when the the school time is in MST' do
             let(:course) { Course.create(conclude_at: '2025-06-24 06:59:00') }
@@ -540,7 +568,7 @@ describe Course do
             let(:course) { Course.create(conclude_at: '2025-06-24 06:59:00') }
 
             before do
-              allow(SettingsService).to receive(:get_settings).and_return('course_end_time' => "11:55 PM UTC")
+              allow(SettingsService).to receive(:get_settings).and_return({'course_end_time' => "11:55 PM UTC", 'timezone' => "UTC"})
             end
             let(:expected_end_time) { "06:55 AM" }
             let(:actual_end_time) {  course.conclude_at.strftime("%H:%M %p") }
@@ -559,7 +587,7 @@ describe Course do
             let(:course) { Course.create(conclude_at: '2025-06-24 06:59:00') }
 
             before do
-              allow(SettingsService).to receive(:get_settings).and_return('course_end_time' => "11:55 PM MDT")
+              allow(SettingsService).to receive(:get_settings).and_return({'course_end_time' => "11:55 PM MDT", 'timezone' => "MT"})
             end
             let(:expected_end_time) { "06:55 AM" }
             let(:actual_end_time) {  course.conclude_at.strftime("%H:%M %p") }
@@ -586,10 +614,10 @@ describe Course do
         allow(SettingsService).to receive(:get_settings).and_return('timezone' => 'MT')
       end
       it 'returns the correct date with an offset of 6 when observing daylight savings' do
-        expect(course.parse_time_in_zone('Sat, 5 Oct 2024 1:00 AM MT')).to eq('2024-10-05 01:00:00.000000000 -0600')
+        expect(course.parse_time_in_zone('1:00 AM MDT', '2024-10-05 06:59:00 UTC')).to eq('2024-10-05 01:00:00.000000000 -0600')
       end
       it 'returns the correct date with an offset of 7 when not observing daylight savings' do
-          expect(course.parse_time_in_zone('Sat, 5 Nov 2024 1:00 AM MT')).to eq('2024-11-05 01:00:00.000000000 -0700')
+          expect(course.parse_time_in_zone('1:00 AM MDT', '2024-11-05 06:59:00 UTC')).to eq('2024-11-05 01:00:00.000000000 -0700')
       end
     end
   end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -318,10 +318,7 @@ describe Course do
 
           context 'when SettingsService course_end_time is in a daylight savings timezone' do
             before do
-              allow(SettingsService).to receive(:get_settings).and_return(
-                'course_end_time' => "11:59 PM MDT",
-                'timezone' => "MT"
-              )
+              allow(SettingsService).to receive(:get_settings).and_return({ 'course_end_time' => "11:59 PM MDT", 'timezone' => "MT" })
             end
 
             context 'when the course concludes at a time when daylight savings is not observed' do
@@ -491,7 +488,7 @@ describe Course do
 
             context 'when course_end_time is in another timezone' do
               before do
-                allow(SettingsService).to receive(:get_settings).and_return('course_end_time' => "11:55 PM EDT", 'timezone' => "ET")
+                allow(SettingsService).to receive(:get_settings).and_return({'course_end_time' => "11:55 PM EDT", 'timezone' => "ET"})
                 course.conclude_at = '2025-06-24 06:59:00'
                 course.save_with_account_times
 


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/QTY-10001)

## Purpose 
Times are not being stored correctly for areas that observe daylight savings

## Approach 
Include the date with the time when calculating UTC offset.  Use ActiveRecord to parse the date/time and calculate UTC offset instead of calculating manually.

## Testing
Passes all specs in  course_spec.rb
