### PR TITLE
(B) QTY-10125: Set grade and score to nil when submission is excused

### DIFF
--- a/app/decorators/models/assignment_decorator.rb
+++ b/app/decorators/models/assignment_decorator.rb
@@ -3,11 +3,17 @@ Assignment.class_eval do
 
   before_save :update_min_score_threshold, if: Proc.new { self.assignment_group_id_changed? && self.assignment_group_id_was != nil }
 
-  def toggle_exclusion(student_id, bool)
+  def toggle_exclusion(student_id, is_excused)
     subs = submissions.where(user_id: student_id)
     if subs.any?
       subs.each do |submission|
-        submission.update(excused: bool)
+        submission.excused = is_excused
+        if is_excused
+          submission.grade = nil
+          submission.score = nil
+        end
+
+        submission.save
       end
     end
   end

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -2,39 +2,54 @@ describe Assignment do
   include_context "stubbed_network"
   let(:assignment) { create(:assignment, :with_assignment_group)}
   let(:user) { User.create }
-  let(:submission) { Submission.create(assignment: assignment, user: user, excused: nil, score: 0.0, grade: 1) }
+  let(:submission) { Submission.create(assignment: assignment, user: user, excused: nil, score: 50, grade: 1) }
   let(:user_2) { User.create }
 
   describe "#toggle_exclusion" do
-    it "flips the excused status to true" do
+    it "sets submission excused to true if is_excused" do
       submission
       assignment.toggle_exclusion(user.id, true)
       submission = assignment.submissions.find_by(user_id: user.id)
       expect(submission.excused).to be true
     end
 
-    it "flips the excused status to false" do
+    it "sets submission score to be nil if is_excused" do
+      submission
+      assignment.toggle_exclusion(user.id, true)
+      submission = assignment.submissions.find_by(user_id: user.id)
+      expect(submission.score).to be nil
+    end
+
+    it "sets submission grade to be nil if is_excused" do
+      submission
+      assignment.toggle_exclusion(user.id, true)
+      submission = assignment.submissions.find_by(user_id: user.id)
+      expect(submission.grade).to be nil
+    end
+
+    it "sets submission excused to false if is_excused is false" do
       submission
       assignment.toggle_exclusion(user.id, false)
       submission = assignment.submissions.find_by(user_id: user.id)
       expect(submission.excused).to be false
     end
 
-    it "returns nil if no user found" do
-      expect(assignment.toggle_exclusion(user_2.id, true)).to be nil
+    it "does not change submission score if is_excused is false" do
+      submission
+      assignment.toggle_exclusion(user.id, false)
+      submission = assignment.submissions.find_by(user_id: user.id)
+      expect(submission.score).to be 50
     end
 
-    it "sets score to be nil if is_excused is true" do
+    it "does not change submission grade to be nil if is_excused is true" do
       submission
-      assignment.toggle_exclusion(user.id, true)
+      assignment.toggle_exclusion(user.id, false)
       submission = assignment.submissions.find_by(user_id: user.id)
-      expect(submission.score).to be nil
+      expect(submission.grade).to be 1
     end
-    it "sets grade to be nil if is_excused is true" do
-      submission
-      assignment.toggle_exclusion(user.id, true)
-      submission = assignment.submissions.find_by(user_id: user.id)
-      expect(submission.grade).to be nil
+
+    it "returns nil if no user found" do
+      expect(assignment.toggle_exclusion(user_2.id, true)).to be nil
     end
   end
 

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -2,7 +2,7 @@ describe Assignment do
   include_context "stubbed_network"
   let(:assignment) { create(:assignment, :with_assignment_group)}
   let(:user) { User.create }
-  let(:submission) { Submission.create(assignment: assignment, user: user, excused: nil) }
+  let(:submission) { Submission.create(assignment: assignment, user: user, excused: nil, score: 0.0, grade: 1) }
   let(:user_2) { User.create }
 
   describe "#toggle_exclusion" do
@@ -22,6 +22,19 @@ describe Assignment do
 
     it "returns nil if no user found" do
       expect(assignment.toggle_exclusion(user_2.id, true)).to be nil
+    end
+
+    it "sets score to be nil" do
+      submission
+      assignment.toggle_exclusion(user.id, true)
+      submission = assignment.submissions.find_by(user_id: user.id)
+      expect(submission.score).to be nil
+    end
+    it "sets grade to be nil" do
+      submission
+      assignment.toggle_exclusion(user.id, true)
+      submission = assignment.submissions.find_by(user_id: user.id)
+      expect(submission.grade).to be nil
     end
   end
 

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -24,13 +24,13 @@ describe Assignment do
       expect(assignment.toggle_exclusion(user_2.id, true)).to be nil
     end
 
-    it "sets score to be nil" do
+    it "sets score to be nil if is_excused is true" do
       submission
       assignment.toggle_exclusion(user.id, true)
       submission = assignment.submissions.find_by(user_id: user.id)
       expect(submission.score).to be nil
     end
-    it "sets grade to be nil" do
+    it "sets grade to be nil if is_excused is true" do
       submission
       assignment.toggle_exclusion(user.id, true)
       submission = assignment.submissions.find_by(user_id: user.id)


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/QTY-10125)

## Purpose 
A submissions grade and score are not being set to nil when an assignment is excused for a user. This is causing the gradebook to not display 'EX'.

## Approach 
Update submission grade and score to nil when excused

## Testing
Specs
