### PR TITLE
BEL-3936 Ensure that ECS scaling will not kill running work

### DIFF
--- a/app/decorators/lib/delayed/worker.rb
+++ b/app/decorators/lib/delayed/worker.rb
@@ -1,0 +1,43 @@
+Delayed::Worker.class_eval do
+  @@mutex = Mutex.new
+  @@active_jobs = 0
+
+  alias_method :original_perform, :perform
+
+  def perform(job)
+    @@mutex.synchronize do
+      @@active_jobs += 1
+      Rails.logger.info("Active jobs for worker #{name}: #{@@active_jobs}")
+      set_task_protection(true) if @@active_jobs == 1
+    end
+    original_perform(job)
+    @@mutex.synchronize do
+      @@active_jobs -= 1
+      Rails.logger.info("Active jobs for worker #{name}: #{@@active_jobs}")
+      set_task_protection(false) if @@active_jobs == 0
+    end
+  end
+
+  def set_task_protection(state)
+    begin
+      ecs_agent_uri = ENV['ECS_AGENT_URI']
+      state_endpoint = "#{ecs_agent_uri}/task-protection/v1/state"
+      uri = URI.parse(state_endpoint)
+      request = Net::HTTP::Put.new(uri)
+      request['Content-Type'] = 'application/json'
+      request.body = { 'ProtectionEnabled' => state }.to_json
+
+      response = Net::HTTP.start(uri.hostname, uri.port) do |http|
+        http.request(request)
+      end
+
+      unless response.is_a?(Net::HTTPSuccess)
+        raise "Failed to update ECS task protection state: #{response.body}"
+      end
+
+    rescue StandardError => e
+      raise "An error occurred: #{e.message}"
+    end
+
+  end
+end

--- a/app/decorators/lib/delayed/worker.rb
+++ b/app/decorators/lib/delayed/worker.rb
@@ -10,12 +10,13 @@ Delayed::Worker.class_eval do
       Rails.logger.info("Pre Perform Active jobs for worker #{name}: #{@@active_jobs}")
       set_task_protection(true) if @@active_jobs == 1
     end
-    original_perform(job)
+    count = original_perform(job)
     @@mutex.synchronize do
       @@active_jobs -= 1
       Rails.logger.info("Post Perform Active jobs for worker #{name}: #{@@active_jobs}")
       set_task_protection(false) if @@active_jobs == 0
     end
+    count
   end
 
   def set_task_protection(state)

--- a/app/decorators/lib/delayed/worker.rb
+++ b/app/decorators/lib/delayed/worker.rb
@@ -20,6 +20,7 @@ Delayed::Worker.class_eval do
   end
 
   def set_task_protection(state)
+    return unless ENV['ECS_AGENT_URI']
     begin
       ecs_agent_uri = ENV['ECS_AGENT_URI']
       state_endpoint = "#{ecs_agent_uri}/task-protection/v1/state"

--- a/app/decorators/lib/delayed/worker.rb
+++ b/app/decorators/lib/delayed/worker.rb
@@ -7,13 +7,13 @@ Delayed::Worker.class_eval do
   def perform(job)
     @@mutex.synchronize do
       @@active_jobs += 1
-      Rails.logger.info("Active jobs for worker #{name}: #{@@active_jobs}")
+      Rails.logger.info("Pre Perform Active jobs for worker #{name}: #{@@active_jobs}")
       set_task_protection(true) if @@active_jobs == 1
     end
     original_perform(job)
     @@mutex.synchronize do
       @@active_jobs -= 1
-      Rails.logger.info("Active jobs for worker #{name}: #{@@active_jobs}")
+      Rails.logger.info("Post Perform Active jobs for worker #{name}: #{@@active_jobs}")
       set_task_protection(false) if @@active_jobs == 0
     end
   end


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-3936)

## Purpose 
<!-- what/why -->
Do not kill running work when we scale down workers.
## Approach 
<!-- how -->
In order to ensure our ECS scaling does not kill running jobs, we need to set task protection while workers are doing work.

We do this by sharing a mutex across all running threads, keeping a count of running jobs in the perform state. When the count gets to 0, unset protected status, and when it increments past 0, set protected status.

## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
Tested on new-id-sandbox - imported cartridge and watched task protection status be turned on and off again.