### PR TITLE
QTY-11338 First draft of debouncing task protection

### DIFF
--- a/app/decorators/lib/delayed/worker.rb
+++ b/app/decorators/lib/delayed/worker.rb
@@ -1,6 +1,12 @@
+require 'concurrent/scheduled_task'
+
 Delayed::Worker.class_eval do
   @@mutex = Mutex.new
   @@active_jobs = 0
+  @@last_task_protection_deactivation = nil
+  @@task_protection_state = false
+  @@deactivation_pending = false
+  @@deactivation_task = nil
 
   alias_method :original_perform, :perform
 
@@ -21,25 +27,57 @@ Delayed::Worker.class_eval do
 
   def set_task_protection(state)
     return unless ENV['ECS_AGENT_URI']
+    return unless state != @@task_protection_state
     begin
-      ecs_agent_uri = ENV['ECS_AGENT_URI']
-      state_endpoint = "#{ecs_agent_uri}/task-protection/v1/state"
-      uri = URI.parse(state_endpoint)
-      request = Net::HTTP::Put.new(uri)
-      request['Content-Type'] = 'application/json'
-      request.body = { 'ProtectionEnabled' => state }.to_json
-
-      response = Net::HTTP.start(uri.hostname, uri.port) do |http|
-        http.request(request)
+      if state
+        cancel_deactivation_task
+        send_task_protection_to_ecs(true) if state
+      else
+        debounced_task_protection_deactivation
       end
 
-      unless response.is_a?(Net::HTTPSuccess)
-        raise "Failed to update ECS task protection state: #{response.body}"
-      end
+      @@task_protection_state = state
 
     rescue StandardError => e
       raise "An error occurred: #{e.message}"
     end
-
   end
+
+  def debounced_task_protection_deactivation
+    return if @@deactivation_pending
+    @@deactivation_pending = true
+    @@deactivation_task = Concurrent::ScheduledTask.execute(60) do
+      @@mutex.synchronize do
+        if @@active_jobs == 0
+          send_task_protection_to_ecs(false)
+          @@deactivation_pending = false
+          @@last_task_protection_deactivation = Time.now
+        end
+      end
+    end
+  end
+
+  def cancel_deactivation_task
+    return unless @@deactivation_task
+    @@deactivation_task.cancel
+    @@deactivation_pending = false
+  end
+
+  def send_task_protection_to_ecs(state)
+    ecs_agent_uri = ENV['ECS_AGENT_URI']
+    state_endpoint = "#{ecs_agent_uri}/task-protection/v1/state"
+    uri = URI.parse(state_endpoint)
+    request = Net::HTTP::Put.new(uri)
+    request['Content-Type'] = 'application/json'
+    request.body = { 'ProtectionEnabled' => state }.to_json
+
+    response = Net::HTTP.start(uri.hostname, uri.port) do |http|
+      http.request(request)
+    end
+
+    unless response.is_a?(Net::HTTPSuccess)
+      raise "Failed to update ECS task protection state: #{response.body}"
+    end
+  end
+
 end

--- a/app/decorators/lib/delayed/worker.rb
+++ b/app/decorators/lib/delayed/worker.rb
@@ -49,8 +49,8 @@ Delayed::Worker.class_eval do
       @@mutex.synchronize do
         if @@active_jobs == 0
           send_task_protection_to_ecs(false)
-          @@deactivation_pending = false
         end
+        @@deactivation_pending = false
       end
     end
   end

--- a/app/decorators/lib/delayed/worker.rb
+++ b/app/decorators/lib/delayed/worker.rb
@@ -3,7 +3,6 @@ require 'concurrent/scheduled_task'
 Delayed::Worker.class_eval do
   @@mutex = Mutex.new
   @@active_jobs = 0
-  @@last_task_protection_deactivation = nil
   @@task_protection_state = false
   @@deactivation_pending = false
   @@deactivation_task = nil

--- a/app/decorators/lib/delayed/worker.rb
+++ b/app/decorators/lib/delayed/worker.rb
@@ -30,7 +30,7 @@ Delayed::Worker.class_eval do
     begin
       if state
         cancel_deactivation_task
-        send_task_protection_to_ecs(true) if state
+        send_task_protection_to_ecs(true)
       else
         debounced_task_protection_deactivation
       end

--- a/app/decorators/lib/delayed/worker.rb
+++ b/app/decorators/lib/delayed/worker.rb
@@ -50,7 +50,6 @@ Delayed::Worker.class_eval do
         if @@active_jobs == 0
           send_task_protection_to_ecs(false)
           @@deactivation_pending = false
-          @@last_task_protection_deactivation = Time.now
         end
       end
     end


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/QTY-11338)

## Purpose 
<!-- what/why -->
Stop hammering the ECS task protection API.
## Approach 
<!-- how -->
We're running up against task protection API limits due to quick bursts of many small tasks. In order to do this, we want to debounce unprotecting tasks and make sure we never double-send updates to task protection. We still, however want to protect a task as soon as we start one.

This is a first draft at doing this. I suspect we can simplify and make this more comprehensible.


## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
In draft, not yet tested.
