### PR TITLE
BEL-4804 Deal with second level of N+1s

### DIFF
--- a/app/decorators/models/course_progress_decorator.rb
+++ b/app/decorators/models/course_progress_decorator.rb
@@ -95,7 +95,7 @@ CourseProgress.class_eval do
   def filter_out_excused_requirements(reqs)
     return reqs unless student_has_excused_submission?
     content_tag_ids = reqs.map { |req| req[:id] }
-    content_tags = ContentTag.where(id: content_tag_ids).index_by(&:id)
+    content_tags = ContentTag.where(id: content_tag_ids).preload(:content).index_by(&:id)
 
     reqs.select do |req|
       ct = content_tags[req[:id]]


### PR DESCRIPTION


[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-4804)

## Purpose 
<!-- what/why -->
There were 3-4 levels of n+1 bugs in this section of code. Fixing 1 of them seems to get us to the point of not triggering the 55s timeout, but we stretch goaled this in.

## Approach 
<!-- how -->
Canvas forbids using .includes(), presumably because they prefer to always make the explicit choice of which behaviour is happening to improve performance, so we have to use preload or eager_load here.

We're choosing preload, because everything that is using this is close by, and that seems less confusing.

## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
Unit testing in CI/CD