### PR TITLE
QTY-13258: Do not query redis enrollment-no. of times

### DIFF
--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -16,11 +16,28 @@ describe Course do
     let(:enrollent_1) { Enrollment.create(course: course, user: user_1, workflow_state: 'active', type: 'StudentEnrollment') }
     let(:enrollent_2) { Enrollment.create(course: course, user: user_2, workflow_state: 'inactive', type: 'StudentEnrollment') }
     let(:enrollent_3) { Enrollment.create(course: course, user: user_3, workflow_state: 'active', type: 'TeacherEnrollment') }
+    
     it "returns the count of 2 users online in the last 5 minutes of" do
-      allow_any_instance_of(User).to receive(:is_online?).and_return(true)
-      allow(enrollent_1).to receive(:workflow_state).and_return('active')
-      allow(enrollent_2).to receive(:workflow_state).and_return('inactive')
-      allow(enrollent_3).to receive(:workflow_state).and_return('active')
+      current_time = Time.now.utc
+      allow(Time).to receive(:now).and_return(current_time)
+
+      # Mock the outer cache fetch
+      allow(Rails.cache).to receive(:fetch).and_yield
+
+      # Mock the inner read_multi to return online status
+      expect(Rails.cache).to receive(:read_multi) do |*keys|
+        # Create a hash of user_id => last_access_time
+        keys.map { |k| 
+          user_id = k.split('/').first
+          # Only return recent times for active enrollments
+          if [user_1.id, user_3.id].include?(user_id.to_i)
+            [k, current_time - 2.minutes]
+          else
+            [k, current_time - 10.minutes]
+          end
+        }.to_h
+      end
+
       expect(course.online_user_count).to eq(2)
     end
   end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -13,31 +13,21 @@ describe Course do
     let(:user_1) { User.create }
     let(:user_2) { User.create }
     let(:user_3) { User.create }
-    let(:enrollent_1) { Enrollment.create(course: course, user: user_1, workflow_state: 'active', type: 'StudentEnrollment') }
-    let(:enrollent_2) { Enrollment.create(course: course, user: user_2, workflow_state: 'inactive', type: 'StudentEnrollment') }
-    let(:enrollent_3) { Enrollment.create(course: course, user: user_3, workflow_state: 'active', type: 'TeacherEnrollment') }
+    let!(:enrollment_1) { Enrollment.create(course: course, user: user_1, workflow_state: 'active', type: 'StudentEnrollment') }
+    let!(:enrollment_2) { Enrollment.create(course: course, user: user_2, workflow_state: 'inactive', type: 'StudentEnrollment') }
+    let!(:enrollment_3) { Enrollment.create(course: course, user: user_3, workflow_state: 'active', type: 'TeacherEnrollment') }
     
-    it "returns the count of 2 users online in the last 5 minutes of" do
+    it "returns the count of 2 users online in the last 5 minutes" do
       current_time = Time.now.utc
       allow(Time).to receive(:now).and_return(current_time)
-
-      # Mock the outer cache fetch
       allow(Rails.cache).to receive(:fetch).and_yield
-
-      # Mock the inner read_multi to return online status
-      expect(Rails.cache).to receive(:read_multi) do |*keys|
-        # Create a hash of user_id => last_access_time
-        keys.map { |k| 
-          user_id = k.split('/').first
-          # Only return recent times for active enrollments
-          if [user_1.id, user_3.id].include?(user_id.to_i)
-            [k, current_time - 2.minutes]
-          else
-            [k, current_time - 10.minutes]
-          end
-        }.to_h
+      allow(Rails.cache).to receive(:read_multi) do |*keys|
+        {
+          "#{user_1.id}/last_access_time" => current_time - 2.minutes,  # Active and recent
+          "#{user_2.id}/last_access_time" => current_time - 10.minutes, # Inactive and old
+          "#{user_3.id}/last_access_time" => current_time - 1.minute    # Active and recent
+        }
       end
-
       expect(course.online_user_count).to eq(2)
     end
   end

--- a/spec/test_app/app/models/enrollment.rb
+++ b/spec/test_app/app/models/enrollment.rb
@@ -4,6 +4,8 @@ class Enrollment < ActiveRecord::Base
   belongs_to :associated_user, :class_name => 'User'
   has_many :scores
 
+  scope :active, -> { where(workflow_state: 'active') }
+
   after_create :distribute_due_dates
   after_commit { PipelineService.publish(self)}
 


### PR DESCRIPTION

[Link to Jira ticket](https://strongmind.atlassian.net/browse/QTY-13258)

## Purpose 
Make course pages with many enrollments faster.

## Approach 
In a before action to set the online count for a course, we are iterating over every active enrollment for that course and setting stuff in redis. This slows down all course pages. Here, by doing redis fetches in batches of 1000, we've noticed an increase in page load times.

## Testing
We spun up a new course added 6500 students, and made a ton of enrollments for them. We then sped up the page significantly by targeting `strongmind_badge_counts_for`, which is problematic.
