### PR TITLE
BEL-5319 Update github actions runner Ubuntu

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     services:
       postgres:
         image: postgres:9-alpine


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-5319)

## Purpose 
<!-- what/why -->
Ubuntu-20.04 hosted runner image is closing down
## Approach 
<!-- how -->
This pull request updates the GitHub Actions workflow configuration for running tests. The most important change is the update of the runner version to use the latest Ubuntu version.

Workflow configuration update:

* [`.github/workflows/rspec.yml`](diffhunk://#diff-1fadaba7942eb03a370984f465dc59789417e580083e4bcaa2d073959b1815beL16-R16): Changed the runner version from `ubuntu-20.04` to `ubuntu-latest` for the `test` job.
