### PR TITLE
QTY-14666: Remove Submitted Check for Autograder

### DIFF
--- a/app/services/grades_service/queries/zero_grader_submissions.rb
+++ b/app/services/grades_service/queries/zero_grader_submissions.rb
@@ -18,7 +18,6 @@ module GradesService
       def submissions_scope
         @scope = Submission
           .joins(assignment: :course)
-          .where('submissions.workflow_state = ?', 'unsubmitted')
           .where(score: nil)
           .where(grade: nil)
           .where('submissions.cached_due_date < ?', 1.hour.ago)


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/QTY-14666)

## Purpose 
<!-- what/why -->
Some submissions are being marked as submitted but aren't being graded and this is causing the autograder to not assign zeros to past due assignments.

## Approach 
<!-- how -->
Remove the workflow check of 'unsubmitted' from the zero out method of the autograder. There are no cases where a submission should have a submitted attribute but the score and the grade are both null. Therefore, if a submission is past its due date, is not exempt, the zero out setting is checked, and both the grade and score are nil, zero out the submission.
