### PR TITLE
(B) BEL-5313: Add error handling for attendance service HTTP responses

### DIFF
--- a/spec/services/attendance_service/commands/check_lockout_spec.rb
+++ b/spec/services/attendance_service/commands/check_lockout_spec.rb
@@ -99,7 +99,9 @@ describe AttendanceService::Commands::CheckLockout do
 
         context "with identity pseudonym" do
           before do
-            allow(HTTParty).to receive(:get).and_return("isLockedOut" => true)
+            response = double(code: 200)
+            allow(response).to receive(:try).with(:fetch, "isLockedOut", false).and_return(true)
+            allow(HTTParty).to receive(:get).and_return(response)
           end
 
           it "returns truthy" do


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-3513)

## Purpose 
<!-- what/why -->
Stop silently failing attendance calls

## Approach 
<!-- how -->
- Added specific error classes for different HTTP response scenarios

- Added comprehensive test coverage for HTTP error handling

- Maintains fail-open behavior while surfacing errors to Sentry



## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
Unit testing, and also will test in dev/stage instances.