### PR TITLE
(B) QTY-14939 Fix hammering attendance API

### DIFF
--- a/app/services/attendance_service/commands/check_lockout.rb
+++ b/app/services/attendance_service/commands/check_lockout.rb
@@ -21,7 +21,7 @@ module AttendanceService
       end
 
       def locked_out?
-        return false unless ENV.fetch('ATTENDANCE_LOCKOUT_DISABLED', true)
+        return false unless ENV.fetch('ATTENDANCE_LOCKOUT_DISABLED', false)
         response = HTTParty.get(full_url, headers: { "CanvasAuth" => auth })
 
         case response.code

--- a/app/services/attendance_service/commands/check_lockout.rb
+++ b/app/services/attendance_service/commands/check_lockout.rb
@@ -19,7 +19,12 @@ module AttendanceService
       def checkable?
         auth && attendance_root && pseudonym && user && partner_name
       end
-      
+
+      def locked_out?
+        return false unless ENV.fetch('ATTENDANCE_LOCKOUT_ENABLED', false)
+        HTTParty.get(full_url, headers: { "CanvasAuth" => auth }).try(:fetch, "isLockedOut", false)
+      end
+
       def partner_name
         @partner_name ||= SettingsService.get_settings(object: 'user', id: user.id)["partner_name"]
       end
@@ -30,10 +35,6 @@ module AttendanceService
 
       def full_url
         "#{attendance_root}/#{partner_name}/Accounts/#{integration_id}/Attendance/Status"
-      end
-
-      def locked_out?
-        HTTParty.get(full_url, headers: { "CanvasAuth" => auth }).try(:fetch, "isLockedOut", false)
       end
     end
   end

--- a/app/services/attendance_service/commands/check_lockout.rb
+++ b/app/services/attendance_service/commands/check_lockout.rb
@@ -17,7 +17,7 @@ module AttendanceService
       attr_reader :pseudonym, :user, :auth, :attendance_root
 
       def checkable?
-        auth && attendance_root && pseudonym && user && partner_name
+        auth && attendance_root && pseudonym && partner_name
       end
 
       def locked_out?

--- a/app/services/attendance_service/commands/check_lockout.rb
+++ b/app/services/attendance_service/commands/check_lockout.rb
@@ -23,9 +23,10 @@ module AttendanceService
       def locked_out?
         return false unless ENV.fetch('ATTENDANCE_LOCKOUT_DISABLED', true)
         response = HTTParty.get(full_url, headers: { "CanvasAuth" => auth })
+
         case response.code
         when 200..299
-          response.try(:fetch, "isLockedOut", false)
+          response['isLockedOut']
         when 401, 403
           raise UnauthorizedError, "Unauthorized access to attendance service"
         when 404

--- a/app/services/attendance_service/commands/check_lockout.rb
+++ b/app/services/attendance_service/commands/check_lockout.rb
@@ -21,7 +21,7 @@ module AttendanceService
       end
 
       def locked_out?
-        return false unless ENV.fetch('ATTENDANCE_LOCKOUT_DISABLED', false)
+        return false if ENV.fetch('ATTENDANCE_LOCKOUT_DISABLED', false)
         response = HTTParty.get(full_url, headers: { "CanvasAuth" => auth })
 
         case response.code

--- a/app/services/attendance_service/commands/check_lockout.rb
+++ b/app/services/attendance_service/commands/check_lockout.rb
@@ -21,8 +21,8 @@ module AttendanceService
       end
 
       def locked_out?
-        return false unless ENV.fetch('ATTENDANCE_LOCKOUT_ENABLED', false)
-        response = HTTParty.get(full_url, headers: { "CanvasAuth" => auth }).try(:fetch, "isLockedOut", false)
+        return false unless ENV.fetch('ATTENDANCE_LOCKOUT_DISABLED', true)
+        response = HTTParty.get(full_url, headers: { "CanvasAuth" => auth })
         case response.code
         when 200..299
           response.try(:fetch, "isLockedOut", false)

--- a/app/services/attendance_service/commands/check_lockout.rb
+++ b/app/services/attendance_service/commands/check_lockout.rb
@@ -26,7 +26,7 @@ module AttendanceService
 
         case response.code
         when 200..299
-          response['isLockedOut']
+          return response['isLockedOut']
         when 401, 403
           raise UnauthorizedError, "Unauthorized access to attendance service"
         when 404

--- a/spec/services/attendance_service/commands/check_lockout_spec.rb
+++ b/spec/services/attendance_service/commands/check_lockout_spec.rb
@@ -115,14 +115,17 @@ describe AttendanceService::Commands::CheckLockout do
           let(:headers) { { "CanvasAuth" => subject.send(:auth) } }
 
           it "is truthy with locked out status" do
-            response = double(code: 200, fetch: true)
-            allow(response).to receive(:try).with(:fetch, "isLockedOut", false).and_return(true)
+            response = double(code: 200, fetch: {
+              "isLockedOut" => "true"
+            })
             allow(HTTParty).to receive(:get).with(url, headers: headers).and_return(response)
             expect(subject.call).to be_truthy
           end
 
           it "is falsy with not locked out status" do
-            response = double(code: 200, fetch: false)
+            response = double(code: 200, fetch: {
+              "isLockedOut" => "false"
+            })
             allow(response).to receive(:try).with(:fetch, "isLockedOut", false).and_return(false)
             allow(HTTParty).to receive(:get).with(url, headers: headers).and_return(response)
             expect(subject.call).to be_falsy

--- a/spec/services/attendance_service/commands/check_lockout_spec.rb
+++ b/spec/services/attendance_service/commands/check_lockout_spec.rb
@@ -183,6 +183,9 @@ describe AttendanceService::Commands::CheckLockout do
     before do
       ENV["ATTENDANCE_LOCKOUT_DISABLED"] = "1"
     end
+    after do
+      ENV["ATTENDANCE_LOCKOUT_DISABLED"] = nil
+    end
     describe '#call' do
       it 'is always falsy' do
         expect(subject.call).to be_falsy
@@ -200,39 +203,39 @@ describe AttendanceService::Commands::CheckLockout do
     end
 
     it "returns true when all required attributes are present" do
-      expect(subject.send(:checkable?)).to be true
+      expect(subject.send(:checkable?)).to be_truthy
     end
 
     it "returns false when auth is missing" do
       allow(subject).to receive(:auth).and_return(nil)
-      expect(subject.send(:checkable?)).to be false
+      expect(subject.send(:checkable?)).to be_falsy
     end
 
     it "returns false when attendance_root is missing" do
       allow(subject).to receive(:attendance_root).and_return(nil)
-      expect(subject.send(:checkable?)).to be false
+      expect(subject.send(:checkable?)).to be_falsy
     end
 
     it "returns false when pseudonym is nil" do
       subject = described_class.new(pseudonym: nil)
-      expect(subject.send(:checkable?)).to be false
+      expect(subject.send(:checkable?)).to be_falsy
     end
 
     it "returns false when user is nil" do
       allow(identity_pseudonym).to receive(:user).and_return(nil)
-      expect(subject.send(:checkable?)).to be false
+      expect(subject.send(:checkable?)).to be_falsy
     end
 
-    it "returns false when partner_name is missing" do
+    it "raises MissingPartner Error when partner_name is missing" do
       allow(SettingsService).to receive(:get_settings).and_return({})
       allow(ENV).to receive(:[]).with('PARTNER_NAME').and_return(nil)
-      expect(subject.send(:checkable?)).to be false
+      expect { subject.send(:checkable?) }.to raise_error(AttendanceService::MissingPartnerError)
     end
 
     it "returns true when partner_name is in ENV but not in settings" do
       allow(SettingsService).to receive(:get_settings).and_return({})
       allow(ENV).to receive(:[]).with('PARTNER_NAME').and_return("env_partner")
-      expect(subject.send(:checkable?)).to be true
+      expect(subject.send(:checkable?)).to be_truthy
     end
   end
 end

--- a/spec/services/attendance_service/commands/check_lockout_spec.rb
+++ b/spec/services/attendance_service/commands/check_lockout_spec.rb
@@ -4,85 +4,93 @@ describe AttendanceService::Commands::CheckLockout do
   let(:user) { User.create(name: "Ryan K Shaw") }
   let(:regular_pseudonym) { Pseudonym.create(user: user, unique_id: "JQUIZZLE", integration_id: "12345") }
   let(:identity_pseudonym) { Pseudonym.create(user: user, unique_id: "JQUEEZY", integration_id: SecureRandom.uuid) }
-  
+
   before do
     allow(SettingsService).to receive(:get_settings).and_return({
       "attendance_root" => "https://google.com",
       "partner_name" => "google",
     })
   end
-  
-  describe "#call" do
-    context "no auth" do
-      it "will not work" do
-        expect(subject).not_to receive(:locked_out?)
-        expect(subject.call).to be false
-      end
-    end
-
-    context "with auth" do
-      before do
-        allow(subject).to receive(:auth).and_return("A REAL API KEY")
-      end
-
-      it "will not work without a user" do
-        nobody = described_class.new(pseudonym: nil)
-        expect(nobody).not_to receive(:locked_out?)
-        expect(nobody.call).to be false
-      end
-
-      context "no partner name" do
-        before do
-          allow(subject).to receive(:partner_name).and_return(nil)
-        end
-
-        it "will not work without a partner name" do
+  context 'with ATTENDANCE_LOCKOUT_ENABLED' do
+    describe "#call" do
+      context "no auth" do
+        it "will not work" do
           expect(subject).not_to receive(:locked_out?)
           expect(subject.call).to be false
         end
       end
 
-      context "no attendance root" do
+      context "with auth" do
         before do
-          allow(subject).to receive(:attendance_root).and_return(nil)
+          allow(subject).to receive(:auth).and_return("A REAL API KEY")
         end
 
-        it "will not work without a partner name" do
-          expect(subject).not_to receive(:locked_out?)
-          expect(subject.call).to be false
-        end
-      end
-
-      context "Checkable passes" do
-        before do
-          allow(subject).to receive(:checkable?).and_return(true)
+        it "will not work without a user" do
+          nobody = described_class.new(pseudonym: nil)
+          expect(nobody).not_to receive(:locked_out?)
+          expect(nobody.call).to be false
         end
 
-        it "will not work without pseudonyms" do
-          expect(subject).to receive(:locked_out?)
-          expect(subject.call).to be_falsy
-        end
-
-        context "with regular pseudonym" do
+        context "no partner name" do
           before do
-            subject.instance_variable_set(:@pseudonym, regular_pseudonym)
+            allow(subject).to receive(:partner_name).and_return(nil)
           end
 
-          it "Still returns falsy" do
+          it "will not work without a partner name" do
+            expect(subject).not_to receive(:locked_out?)
+            expect(subject.call).to be false
+          end
+        end
+
+        context "no attendance root" do
+          before do
+            allow(subject).to receive(:attendance_root).and_return(nil)
+          end
+
+          it "will not work without a partner name" do
+            expect(subject).not_to receive(:locked_out?)
+            expect(subject.call).to be false
+          end
+        end
+
+        context "Checkable passes" do
+          before do
+            allow(subject).to receive(:checkable?).and_return(true)
+          end
+
+          it "will not work without pseudonyms" do
             expect(subject).to receive(:locked_out?)
             expect(subject.call).to be_falsy
           end
-        end
 
-        context "with identity pseudonym" do
-          before do
-            allow(HTTParty).to receive(:get).and_return("isLockedOut" => true)
+          context "with regular pseudonym" do
+            before do
+              subject.instance_variable_set(:@pseudonym, regular_pseudonym)
+            end
+
+            it "Still returns falsy" do
+              expect(subject).to receive(:locked_out?)
+              expect(subject.call).to be_falsy
+            end
           end
 
-          it "returns truthy" do
-            expect(subject.call).to be_truthy
+          context "with identity pseudonym" do
+            before do
+              allow(HTTParty).to receive(:get).and_return("isLockedOut" => true)
+            end
+
+            it "returns truthy" do
+              expect(subject.call).to be_truthy
+            end
           end
         end
+      end
+    end
+  end
+  context 'without ATTENDANCE_LOCKOUT_ENABLED' do
+    describe '#call' do
+      it 'is always falsy' do
+        expect(subject.call).to be_falsy
       end
     end
   end

--- a/spec/services/attendance_service/commands/check_lockout_spec.rb
+++ b/spec/services/attendance_service/commands/check_lockout_spec.rb
@@ -100,7 +100,7 @@ describe AttendanceService::Commands::CheckLockout do
         context "with identity pseudonym" do
           before do
             response = double(code: 200)
-            allow(response).to receive(:try).with(:fetch, "isLockedOut", false).and_return(true)
+            allow(response).to receive(:[]).with('isLockedOut').and_return(true)
             allow(HTTParty).to receive(:get).and_return(response)
           end
 
@@ -115,13 +115,15 @@ describe AttendanceService::Commands::CheckLockout do
           let(:headers) { { "CanvasAuth" => subject.send(:auth) } }
 
           it "is truthy with locked out status" do
-            response = double(code: 200, "isLockedOut" => true)
+            response = double(code: 200)
+            allow(response).to receive(:[]).with('isLockedOut').and_return(true)
             allow(HTTParty).to receive(:get).with(url, headers: headers).and_return(response)
             expect(subject.call).to be_truthy
           end
 
           it "is falsy with not locked out status" do
             response = double(code: 200, "isLockedOut" => false)
+            allow(response).to receive(:[]).with('isLockedOut').and_return(false)
             allow(HTTParty).to receive(:get).with(url, headers: headers).and_return(response)
             expect(subject.call).to be_falsy
           end

--- a/spec/services/attendance_service/commands/check_lockout_spec.rb
+++ b/spec/services/attendance_service/commands/check_lockout_spec.rb
@@ -6,6 +6,7 @@ describe AttendanceService::Commands::CheckLockout do
   let(:identity_pseudonym) { Pseudonym.create(user: user, unique_id: "JQUEEZY", integration_id: SecureRandom.uuid) }
 
   before do
+    allow(HTTParty).to receive(:get)
     allow(SettingsService).to receive(:get_settings).and_return({
       "attendance_root" => "https://google.com",
       "partner_name" => "google",
@@ -218,11 +219,6 @@ describe AttendanceService::Commands::CheckLockout do
 
     it "returns false when pseudonym is nil" do
       subject = described_class.new(pseudonym: nil)
-      expect(subject.send(:checkable?)).to be_falsy
-    end
-
-    it "returns false when user is nil" do
-      allow(identity_pseudonym).to receive(:user).and_return(nil)
       expect(subject.send(:checkable?)).to be_falsy
     end
 

--- a/spec/services/attendance_service/commands/check_lockout_spec.rb
+++ b/spec/services/attendance_service/commands/check_lockout_spec.rb
@@ -11,7 +11,7 @@ describe AttendanceService::Commands::CheckLockout do
       "partner_name" => "google",
     })
   end
-  context 'with ATTENDANCE_LOCKOUT_ENABLED' do
+  context 'without ATTENDANCE_LOCKOUT_DISABLED' do
     describe "#call" do
       context "no auth" do
         it "will not work" do
@@ -176,7 +176,10 @@ describe AttendanceService::Commands::CheckLockout do
       end
     end
   end
-  context 'without ATTENDANCE_LOCKOUT_ENABLED' do
+  context 'with ATTENDANCE_LOCKOUT_DISABLED' do
+    before do
+      allow(ENV).to receive(:[]).with("ATTENDANCE_LOCKOUT_DISABLED").and_return("1")
+    end
     describe '#call' do
       it 'is always falsy' do
         expect(subject.call).to be_falsy

--- a/spec/services/attendance_service/commands/check_lockout_spec.rb
+++ b/spec/services/attendance_service/commands/check_lockout_spec.rb
@@ -178,7 +178,7 @@ describe AttendanceService::Commands::CheckLockout do
   end
   context 'with ATTENDANCE_LOCKOUT_DISABLED' do
     before do
-      allow(ENV).to receive(:[]).with("ATTENDANCE_LOCKOUT_DISABLED").and_return("1")
+      ENV["ATTENDANCE_LOCKOUT_DISABLED"] = "1"
     end
     describe '#call' do
       it 'is always falsy' do

--- a/spec/services/attendance_service/commands/check_lockout_spec.rb
+++ b/spec/services/attendance_service/commands/check_lockout_spec.rb
@@ -113,6 +113,9 @@ describe AttendanceService::Commands::CheckLockout do
         context "HTTP response handling" do
           let(:url) { subject.send(:full_url) }
           let(:headers) { { "CanvasAuth" => subject.send(:auth) } }
+          before do
+            allow(subject).to receive(:checkable?).and_return(true)
+          end
 
           it "is truthy with locked out status" do
             response = double(code: 200)

--- a/spec/services/attendance_service/commands/check_lockout_spec.rb
+++ b/spec/services/attendance_service/commands/check_lockout_spec.rb
@@ -115,18 +115,13 @@ describe AttendanceService::Commands::CheckLockout do
           let(:headers) { { "CanvasAuth" => subject.send(:auth) } }
 
           it "is truthy with locked out status" do
-            response = double(code: 200, fetch: {
-              "isLockedOut" => "true"
-            })
+            response = double(code: 200, "isLockedOut" => true)
             allow(HTTParty).to receive(:get).with(url, headers: headers).and_return(response)
             expect(subject.call).to be_truthy
           end
 
           it "is falsy with not locked out status" do
-            response = double(code: 200, fetch: {
-              "isLockedOut" => "false"
-            })
-            allow(response).to receive(:try).with(:fetch, "isLockedOut", false).and_return(false)
+            response = double(code: 200, "isLockedOut" => false)
             allow(HTTParty).to receive(:get).with(url, headers: headers).and_return(response)
             expect(subject.call).to be_falsy
           end

--- a/spec/support/examples/stubbed_network_context.rb
+++ b/spec/support/examples/stubbed_network_context.rb
@@ -5,6 +5,7 @@ RSpec.shared_context "stubbed_network" do
     allow(SettingsService).to receive(:get_settings).and_return({})
     allow(SettingsService).to receive(:update_settings).and_return({})
     allow(HTTParty).to receive(:post)
+    allow(HTTParty).to receive(:get)
     allow(PipelineService::HTTPClient).to receive(:post)
     allow(PipelineService::HTTPClient).to receive(:get).and_return(double('response', parsed_response: ''))
   end

--- a/spec/support/examples/stubbed_network_context.rb
+++ b/spec/support/examples/stubbed_network_context.rb
@@ -5,7 +5,6 @@ RSpec.shared_context "stubbed_network" do
     allow(SettingsService).to receive(:get_settings).and_return({})
     allow(SettingsService).to receive(:update_settings).and_return({})
     allow(HTTParty).to receive(:post)
-    allow(HTTParty).to receive(:get)
     allow(PipelineService::HTTPClient).to receive(:post)
     allow(PipelineService::HTTPClient).to receive(:get).and_return(double('response', parsed_response: ''))
   end


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/QTY-14939)

## Purpose 
<!-- what/why -->
For schools that do not use attendance lockouts, we are currently hitting the attendance API and getting a 404, triggering an exception to sentry and causing attendance API to do way more work than it should.

## Approach 
<!-- how -->
Fix this by checking for an env var ( ATTENDANCE_LOCKOUT_DISABLED ).

## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
Manual testing + unit testing
