### PR TITLE
(B) QTY-17508: Fix course setting update issue on potential nil object

### DIFF
--- a/app/decorators/models/course_decorator.rb
+++ b/app/decorators/models/course_decorator.rb
@@ -110,7 +110,8 @@ Course.class_eval do
   end
 
   def save_with_account_times
-    set_course_start_end_time_from_school.save
+    set_course_start_end_time_from_school
+    save
   end
 
   def course_start_time_from_school


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/QTY-17508)

## Purpose 
When user update course setting without start and end time, it will throw a nil error.

## Approach 
Move save method to the next line to avoid early implicit return

## Testing
Test to save/update course without start and end time
