### PR TITLE
Add SQS payload size guard and structured logging for Pipeline V2 publish

### DIFF
--- a/app/services/pipeline_service/V2/client.rb
+++ b/app/services/pipeline_service/V2/client.rb
@@ -3,6 +3,14 @@ module PipelineService
     class Client
       REGION = ENV['AWS_REGION']
       SQS_REGION = 'us-west-2'
+
+      SQS_MAX_BYTES = 262_144
+      SIZE_WARNING_RATIO = 0.9
+      LOG_TAG = '[pipeline_v2_payload_size]'.freeze
+      JOB_TAG = 'PipelineService::V2::API::Publish#call'.freeze
+
+      class PayloadTooLargeError < StandardError; end
+
       include Singleton
 
       def initialize
@@ -24,7 +32,69 @@ module PipelineService
       end
 
       def publish(payload)
-        @sqs.send_message(queue_url: @url, message_body: payload.to_json)
+        message_body = payload.to_json
+        bytesize = message_body.bytesize
+
+        if bytesize > SQS_MAX_BYTES
+          log_payload_size(payload, bytesize, :oversize)
+          raise PayloadTooLargeError,
+                "PipelineService V2 payload exceeds SQS limit " \
+                "(bytesize=#{bytesize} limit_bytes=#{SQS_MAX_BYTES})"
+        end
+
+        if bytesize > (SQS_MAX_BYTES * SIZE_WARNING_RATIO)
+          log_payload_size(payload, bytesize, :near_limit)
+        end
+
+        @sqs.send_message(queue_url: @url, message_body: message_body)
+      end
+
+      private
+
+      def log_payload_size(payload, bytesize, threshold_state)
+        line = "#{LOG_TAG} " + payload_log_attributes(payload, bytesize, threshold_state).join(' ')
+
+        case threshold_state
+        when :oversize
+          Rails.logger.error(line)
+        when :near_limit
+          Rails.logger.warn(line)
+        end
+      end
+
+      def payload_log_attributes(payload, bytesize, threshold_state)
+        attrs = [
+          "threshold_state=#{threshold_state}",
+          "bytesize=#{bytesize}",
+          "limit_bytes=#{SQS_MAX_BYTES}",
+          "job_tag=#{JOB_TAG}",
+          "noun=#{value_of(payload, :noun).inspect}",
+          "canvas_domain=#{value_of(value_of(payload, :meta), :domain_name).inspect}",
+          "status=#{value_of(value_of(payload, :meta), :status).inspect}"
+        ]
+
+        identifiers = value_of(payload, :identifiers)
+        if identifiers.is_a?(Hash)
+          identifiers.each do |k, v|
+            attrs << "identifier_#{k}=#{v.inspect}"
+          end
+        end
+
+        data = value_of(payload, :data)
+        if data.is_a?(Hash)
+          history = value_of(data, :submission_history)
+          attrs << "submission_history_count=#{history.size}" if history.is_a?(Array)
+          attrs << "data_keys=#{data.keys.map(&:to_s).sort.join(',').inspect}"
+        end
+
+        attrs
+      end
+
+      def value_of(hash, key)
+        return nil unless hash.is_a?(Hash)
+        return hash[key] if hash.key?(key)
+        return hash[key.to_s] if hash.key?(key.to_s)
+        nil
       end
     end
   end

--- a/spec/services/pipeline_service/V2/client_spec.rb
+++ b/spec/services/pipeline_service/V2/client_spec.rb
@@ -1,31 +1,122 @@
 describe PipelineService::V2::Client do
   include_context 'stubbed_network'
-  describe '#publish' do
-    let(:sqs_instance) { double('sqs_instance') }
 
-    before do
-      allow(SettingsService).to receive(:get_settings).and_return(
-        'pipeline_sqs_url' => 'sqs_url'
-      )
-      allow(Aws::SQS::Client).to receive(:new).and_return(sqs_instance)
-    end
+  describe '#publish' do
+    let(:sqs_instance) { double('sqs_instance', send_message: nil) }
 
     let(:payload) do
       {
         :noun => "page_view",
-        :meta => { :source=>"canvas", :domain_name=>"localhost", :api_version=>1, :status=>nil },
-        :identifiers => { :id=>"f52127ea-261a-407c-8f2c-e97ce8fc6ebb" },
+        :meta => { :source => "canvas", :domain_name => "localhost", :api_version => 1, :status => nil },
+        :identifiers => { :id => "f52127ea-261a-407c-8f2c-e97ce8fc6ebb" },
         :data => {}
       }
     end
 
-    it 'calls sqs' do
-      expect(sqs_instance).to receive(:send_message)
-        .with(
-          queue_url: 'sqs_url',
-          message_body: payload.to_json
+    before do
+      Singleton.__init__(PipelineService::V2::Client)
+      allow(SettingsService).to receive(:get_settings).and_return(
+        'pipeline_sqs_url' => 'sqs_url'
+      )
+      allow(Aws::SQS::Client).to receive(:new).and_return(sqs_instance)
+      allow(Rails.logger).to receive(:warn)
+      allow(Rails.logger).to receive(:error)
+    end
+
+    context 'when the payload is well under the SQS limit' do
+      it 'sends the serialized payload to sqs' do
+        expect(sqs_instance).to receive(:send_message)
+          .with(queue_url: 'sqs_url', message_body: payload.to_json)
+        PipelineService::V2::Client.publish(payload)
+      end
+
+      it 'does not emit a payload-size log entry' do
+        PipelineService::V2::Client.publish(payload)
+        expect(Rails.logger).not_to have_received(:warn)
+        expect(Rails.logger).not_to have_received(:error)
+      end
+    end
+
+    context 'when the payload is near the SQS limit' do
+      let(:near_limit_blob) { 'x' * (PipelineService::V2::Client::SQS_MAX_BYTES - 500) }
+      let(:near_limit_payload) { payload.merge(data: { blob: near_limit_blob }) }
+
+      it 'still publishes to sqs' do
+        expect(sqs_instance).to receive(:send_message)
+        PipelineService::V2::Client.publish(near_limit_payload)
+      end
+
+      it 'logs a structured warning with identifying metadata' do
+        PipelineService::V2::Client.publish(near_limit_payload)
+        expect(Rails.logger).to have_received(:warn) do |line|
+          expect(line).to include('[pipeline_v2_payload_size]')
+          expect(line).to include('threshold_state=near_limit')
+          expect(line).to match(/bytesize=\d+/)
+          expect(line).to include("limit_bytes=#{PipelineService::V2::Client::SQS_MAX_BYTES}")
+          expect(line).to include('noun="page_view"')
+          expect(line).to include('canvas_domain="localhost"')
+          expect(line).to include('identifier_id="f52127ea-261a-407c-8f2c-e97ce8fc6ebb"')
+          expect(line).to include('job_tag=PipelineService::V2::API::Publish#call')
+        end
+      end
+
+      it 'does not include the raw payload contents in the log line' do
+        PipelineService::V2::Client.publish(near_limit_payload)
+        expect(Rails.logger).to have_received(:warn) do |line|
+          expect(line).not_to include(near_limit_blob)
+        end
+      end
+    end
+
+    context 'when the payload exceeds the SQS limit' do
+      let(:oversize_blob) { 'y' * (PipelineService::V2::Client::SQS_MAX_BYTES + 1_000) }
+      let(:oversize_payload) do
+        payload.merge(
+          identifiers: { id: 22970755, assignment_id: 73143, course_id: 502 },
+          data: { blob: oversize_blob, submission_history: [{}, {}, {}] }
         )
-      PipelineService::V2::Client.publish(payload)
+      end
+
+      it 'does not call sqs' do
+        expect(sqs_instance).not_to receive(:send_message)
+        expect { PipelineService::V2::Client.publish(oversize_payload) }
+          .to raise_error(PipelineService::V2::Client::PayloadTooLargeError)
+      end
+
+      it 'raises with bytesize and limit context in the error message' do
+        expect { PipelineService::V2::Client.publish(oversize_payload) }
+          .to raise_error(
+            PipelineService::V2::Client::PayloadTooLargeError,
+            /bytesize=\d+ limit_bytes=#{PipelineService::V2::Client::SQS_MAX_BYTES}/
+          )
+      end
+
+      it 'logs a structured error with identifying metadata before raising' do
+        expect { PipelineService::V2::Client.publish(oversize_payload) }
+          .to raise_error(PipelineService::V2::Client::PayloadTooLargeError)
+
+        expect(Rails.logger).to have_received(:error) do |line|
+          expect(line).to include('[pipeline_v2_payload_size]')
+          expect(line).to include('threshold_state=oversize')
+          expect(line).to match(/bytesize=\d+/)
+          expect(line).to include('noun="page_view"')
+          expect(line).to include('canvas_domain="localhost"')
+          expect(line).to include('identifier_id=22970755')
+          expect(line).to include('identifier_assignment_id=73143')
+          expect(line).to include('identifier_course_id=502')
+          expect(line).to include('submission_history_count=3')
+          expect(line).to include('data_keys="blob,submission_history"')
+        end
+      end
+
+      it 'does not leak the raw payload contents in the log line' do
+        expect { PipelineService::V2::Client.publish(oversize_payload) }
+          .to raise_error(PipelineService::V2::Client::PayloadTooLargeError)
+
+        expect(Rails.logger).to have_received(:error) do |line|
+          expect(line).not_to include(oversize_blob)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/QTY-19270)

## Purpose
Prevent Aws::SQS::Errors::InvalidParameterValue when pipeline payloads exceed the 256 KB SQS message limit.

## Approach
- Serialize publish payloads once and compare bytesize to SQS_MAX_BYTES (262144).
- Log structured pipeline_v2_payload_size lines at warn (>90% of limit) and error (over limit) with noun, identifiers, domain, submission_history_count, and data_keys—without dumping raw payload bodies.
- Raise PayloadTooLargeError before send_message when over limit so jobs fail with clear context instead of opaque AWS errors.

## Testing
- Cover under-limit publish, near-limit warning + send, oversize error + no SQS, and verify logs never include oversized blob content.