### PR TITLE
FSTN-4789: Migrate feature flags from LaunchDarkly to GrowthBook

### DIFF
--- a/app/decorators/controllers/accounts_controller_decorator.rb
+++ b/app/decorators/controllers/accounts_controller_decorator.rb
@@ -34,7 +34,7 @@ AccountsController.class_eval do
 
     @module_editing_disabled = RequirementsService.disable_module_editing_on?
 
-    @expose_discussion_and_project_threshold_field = Rails.configuration.launch_darkly_client.variation("expose-discussion-and-project-threshold-field", @launch_darkly_user, false)
+    @expose_discussion_and_project_threshold_field = GrowthbookService.enabled?("expose-discussion-and-project-threshold-field", attributes: { id: @feature_flag_data[:key] })
 
     js_env({
       HOLIDAYS: @holidays,

--- a/app/decorators/controllers/courses_controller_decorator.rb
+++ b/app/decorators/controllers/courses_controller_decorator.rb
@@ -115,7 +115,7 @@ CoursesController.class_eval do
 
 
   def strongmind_settings
-    @expose_course_level_passing_threshold_fields = Rails.configuration.launch_darkly_client.variation("expose-course-level-passing-threshold-fields", @launch_darkly_user, false)
+    @expose_course_level_passing_threshold_fields = GrowthbookService.enabled?("expose-course-level-passing-threshold-fields", attributes: { id: @feature_flag_data[:key] })
     @assignment_group_thresholds = get_course_thresholds(passing_threshold_group_names)
     get_course_dates
     hide_destructive_course_options?

--- a/app/decorators/models/discussion_topic/materialized_view_decorator.rb
+++ b/app/decorators/models/discussion_topic/materialized_view_decorator.rb
@@ -3,7 +3,7 @@ DiscussionTopic::MaterializedView.class_eval do
     graded_discussion = self.discussion_topic.graded_discussion?
     opts[:show_other_users_submissions] = false
     entry_ids = nil
-    if graded_discussion && launch_darkly_render_discussion_entries(opts[:launch_darkly_user])
+    if graded_discussion && render_discussion_entries_for_graded_submissions?(opts[:feature_flag_data])
       student_submission_graded = self.discussion_topic.assignment.submissions.graded.where(user_id: opts[:user_id]).any?
       if student_submission_graded
         opts[:show_other_users_submissions] = true
@@ -24,7 +24,7 @@ DiscussionTopic::MaterializedView.class_eval do
   alias_method :instructure_materialized_view_json, :materialized_view_json
   alias_method :materialized_view_json, :strongmind_materialized_view_json
 
-  def launch_darkly_render_discussion_entries(ld_user)
-    Rails.configuration.launch_darkly_client.variation("expose-discussion-entries-only-if-graded-submission-exists", ld_user, false)
+  def render_discussion_entries_for_graded_submissions?(feature_flag_data)
+    GrowthbookService.enabled?("expose-discussion-entries-only-if-graded-submission-exists", attributes: { id: feature_flag_data&.dig(:key) })
   end
 end

--- a/app/decorators/models/submission_decorator.rb
+++ b/app/decorators/models/submission_decorator.rb
@@ -114,7 +114,9 @@ Submission.class_eval do
   end
 
   def expose_guided_practice_submission_alerts
-    return true if Rails.env.development? || Rails.env.test?
-    Rails.configuration.launch_darkly_client.variation("expose-guided-practice-submitted-alerts", @launch_darkly_user, false)
+    return true if Rails.env.test?
+    domain = ENV['SETTINGS_TABLE_PREFIX']
+    key = "#{domain.to_s.split('.')[0]}-#{user_id}"
+    GrowthbookService.enabled?("expose-guided-practice-submitted-alerts", attributes: { id: key })
   end
 end


### PR DESCRIPTION
## Summary
- Replace all `LaunchDarkly::LDClient#variation` calls with `GrowthbookService.enabled?` across canvas_shim decorators
- Rename `@launch_darkly_user` / `launch_darkly_user` to `@feature_flag_data` / `set_feature_flag_data` for provider-agnostic naming
- Rename opt key `:launch_darkly_user` → `:feature_flag_data` passed through `materialized_view`
- Rename internal method `launch_darkly_render_discussion_entries` → `render_discussion_entries_for_graded_submissions?`

## Flags migrated
| Flag | File |
|------|------|
| `expose-course-level-passing-threshold-fields` | `courses_controller_decorator.rb` |
| `expose-discussion-and-project-threshold-field` | `accounts_controller_decorator.rb` |
| `expose-discussion-entries-only-if-graded-submission-exists` | `materialized_view_decorator.rb` |
| `expose-guided-practice-submitted-alerts` | `submission_decorator.rb` |

## Test plan
- [ ] CI rspec suite passes
- [ ] Verify GrowthBook flags are configured in GB dashboard with matching flag keys
- [ ] Smoke test each affected feature (course settings threshold fields, account settings threshold field, discussion entry filtering, guided practice submission alerts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)